### PR TITLE
Add [Exposed=*] to expose on all globals

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7002,6 +7002,17 @@ which form (or forms) it is in:
             <code>[Exposed=(Window,Worker)]</code>
         </td>
     </tr>
+    <tr>
+        <td>
+            <emu-nt><a href="#prod-ExtendedAttributeWildcard">ExtendedAttributeWildcard</a></emu-nt>
+        </td>
+        <td>
+            <dfn id="dfn-xattr-wildcard" for="extended attribute" export>takes a wildcard</dfn>
+        </td>
+        <td>
+            <code>[Exposed=*]</code>
+        </td>
+    </tr>
 
 </table>
 
@@ -7063,6 +7074,7 @@ five forms are allowed.
         "="
         "&gt;"
         "?"
+        "*"
         "ByteString"
         "DOMString"
         "FrozenArray"
@@ -7125,6 +7137,11 @@ five forms are allowed.
 <pre class="grammar" id="prod-ExtendedAttributeIdent">
     ExtendedAttributeIdent :
         identifier "=" identifier
+</pre>
+
+<pre class="grammar" id="prod-ExtendedAttributeWildcard">
+    ExtendedAttributeWildcard :
+        identifier "=" "*"
 </pre>
 
 <pre class="grammar" id="prod-ExtendedAttributeIdentList">
@@ -9588,14 +9605,30 @@ it indicates that the construct is exposed
 on that particular set of global interfaces.
 
 The [{{Exposed}}] [=extended attribute=] must either
-[=takes an identifier|take an identifier=] or
-[=takes an identifier list|take an identifier list=].
+[=takes an identifier|take an identifier=],
+[=takes an identifier list|take an identifier list=] or
+[=takes a wildcard|take a wildcard=].
 Each of the identifiers mentioned must be a [=global name=] and be unique.
-This list of identifiers is known as the construct's
-<dfn>own exposure set</dfn>.
+
+The <dfn>own exposure set</dfn> is the set of [=global name=]s which
+[{{Exposed}}] is applied to.
+
+If the [{{Exposed}}] [=extended attribute=]
+[=takes an identifier|take an identifier=] or
+[=takes an identifier list|take an identifier list=],
+the [=own exposure set=] is the list of identifiers.
+If the [{{Exposed}}] [=extended attribute=]
+[=takes a wildcard|take a wildcard=], the [=own exposure set=] is the
+set of interfaces which have the [{{Global}}] extended attribute.
+
+<p class="advisement">
+    <code>[Exposed=*]</code> should be used with care. It is only appropriate
+    when an interface does not expose significant new capabilities. If the
+    interface may be restricted or disabled in some environments, it is
+    recommended to list the globals explicitly.
+</p>
 
 <div algorithm>
-
     To get the <dfn id="dfn-exposure-set" export>exposure set</dfn> of a construct |C|,
     run the following steps:
 

--- a/index.bs
+++ b/index.bs
@@ -9608,24 +9608,25 @@ The [{{Exposed}}] [=extended attribute=] must either
 [=takes an identifier|take an identifier=],
 [=takes an identifier list|take an identifier list=] or
 [=takes a wildcard|take a wildcard=].
-Each of the identifiers mentioned must be a [=global name=] and be unique.
+Each of the identifiers mentioned must be a [=global name=] of some [=interface=] and be unique.
 
-The <dfn>own exposure set</dfn> is the set of [=global name=]s which
-[{{Exposed}}] is applied to.
+The <dfn>own exposure set</dfn> is the [=/set=] of identifiers defined as follows:
 
-If the [{{Exposed}}] [=extended attribute=]
-[=takes an identifier|take an identifier=] or
-[=takes an identifier list|take an identifier list=],
-the [=own exposure set=] is the list of identifiers.
-If the [{{Exposed}}] [=extended attribute=]
-[=takes a wildcard|take a wildcard=], the [=own exposure set=] is the
-set of interfaces which have the [{{Global}}] extended attribute.
+<dl class="switch">
+     :  If the [{{Exposed}}] [=extended attribute=] [=takes an identifier=] |I|
+     :: The [=own exposure set=] is the [=/set=] « |I| ».
+     :  If the [{{Exposed}}] [=extended attribute=] [=takes an identifier list=] |I|
+     :: The [=own exposure set=] is the [=/set=] |I|.
+     :  If the [{{Exposed}}] [=extended attribute=] [=takes a wildcard=]
+     :: The [=own exposure set=] is the [=/set=] of [=global names=] of [=interfaces=] which have the
+        [{{Global}}] [=extended attribute=].
+</dl>
 
 <p class="advisement">
-    <code>[Exposed=*]</code> should be used with care. It is only appropriate
-    when an interface does not expose significant new capabilities. If the
-    interface may be restricted or disabled in some environments, it is
-    recommended to list the globals explicitly.
+    <code>[Exposed=*]</code> is to be used with care.
+    It is only appropriate when an API does not expose significant new capabilities.
+    If the API might be restricted or disabled in some environments,
+    it is preferred to list the globals explicitly.
 </p>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -9618,8 +9618,8 @@ The <dfn>own exposure set</dfn> is the [=/set=] of identifiers defined as follow
      :  If the [{{Exposed}}] [=extended attribute=] [=takes an identifier list=] |I|
      :: The [=own exposure set=] is the [=/set=] |I|.
      :  If the [{{Exposed}}] [=extended attribute=] [=takes a wildcard=]
-     :: The [=own exposure set=] is the [=/set=] of [=global names=] of [=interfaces=] which have the
-        [{{Global}}] [=extended attribute=].
+     :: The [=own exposure set=] is the [=/set=] of all [=global names=] of all [=interfaces=]
+        which have the [{{Global}}] [=extended attribute=].
 </dl>
 
 <p class="advisement">


### PR DESCRIPTION
This patch adds support in WebIDL for declaring an interface available
in all contexts.

Closes #468 

This PR follows the syntax and outline suggested by @tobie . Thanks for your clear instructions here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/littledan/webidl/pull/526.html" title="Last updated on Feb 23, 2018, 2:43 PM GMT (2e23cfb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/526/3750d7a...littledan:2e23cfb.html" title="Last updated on Feb 23, 2018, 2:43 PM GMT (2e23cfb)">Diff</a>