### PR TITLE
Improve the named property visibility algorithm for Window.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10964,7 +10964,7 @@ is the concatenation of the [=interface=]’s
         Note: For example, if the [=interface=] is the {{Window}} interface,
         then the sole object will be this global environment’s window object.
     1.  If the result of running the [=named property visibility algorithm=] with
-        property name |P|, object |object| and object |O| is true, then:
+        |P|, |object|, and |O| is true, then:
         1.  Let |operation| be the operation used to declare the named property getter.
         1.  Let |value| be an uninitialized variable.
         1.  If |operation| was defined without an [=identifier=], then
@@ -12545,7 +12545,7 @@ Issue: Define those internal methods imperatively instead.
     1.  If |O| [=support named properties|supports named properties=],
         |O| does not implement an [=interface=] with the [{{Global}}] [=extended attribute=]
         and the result of calling the [=named property visibility algorithm=]
-        with property name |P| and object |O| is true, then:
+        with |P| and |O| is true, then:
         1.  If |O| does not implement an interface with a [=named property deleter=], then return <emu-val>false</emu-val>.
         1.  Let |operation| be the operation used to declare the named property deleter.
         1.  If |operation| was defined without an [=identifier=], then:
@@ -12643,7 +12643,7 @@ internal method as follows.
     1.  If |P| is not a [=supported property name=] of |O|, then return false.
     1.  If |propertyHolder| has an own property named |P|, then return false.
 
-          Note: This will include cases in which |O| has unforgeable properties,
+          Note: This will include cases in which |propertyHolder| has unforgeable properties,
           because in practice those are always set up before objects have any supported property names,
           and once set up will make the corresponding named properties invisible.
 
@@ -12742,7 +12742,7 @@ internal method as follows.
     1.  If |O| [=support named properties|supports named properties=] and
         |ignoreNamedProps| is false, then:
         1.  If the result of running the [=named property visibility algorithm=] with
-            property name |P| and object |O| is true, then:
+            |P| and |O| is true, then:
             1.  Let |operation| be the operation used to declare the named property getter.
             1.  Let |value| be an uninitialized variable.
             1.  If |operation| was defined without an [=identifier=], then

--- a/index.bs
+++ b/index.bs
@@ -10964,7 +10964,7 @@ is the concatenation of the [=interface=]’s
         Note: For example, if the [=interface=] is the {{Window}} interface,
         then the sole object will be this global environment’s window object.
     1.  If the result of running the [=named property visibility algorithm=] with
-        property name |P| and object |object| is true, then:
+        property name |P|, object |object| and object |O| is true, then:
         1.  Let |operation| be the operation used to declare the named property getter.
         1.  Let |value| be an uninitialized variable.
         1.  If |operation| was defined without an [=identifier=], then
@@ -12636,10 +12636,12 @@ internal method as follows.
     is used to determine if a given named property is exposed on an object.
     Some named properties are not exposed on an object depending on whether
     the [{{OverrideBuiltins}}] [=extended attribute=] was used.
-    The algorithm operates as follows, with property name |P| and object |O|:
+    The algorithm operates as follows, with property name |P|, object |O|, and
+    optionally object |propertyHolder|:
 
+    1.  If |propertyHolder| was not specified, set |propertyHolder| to |O|.
     1.  If |P| is not a [=supported property name=] of |O|, then return false.
-    1.  If |O| has an own property named |P|, then return false.
+    1.  If |propertyHolder| has an own property named |P|, then return false.
 
           Note: This will include cases in which |O| has unforgeable properties,
           because in practice those are always set up before objects have any supported property names,
@@ -12647,10 +12649,9 @@ internal method as follows.
 
     1.  If |O| implements an interface that has the [{{OverrideBuiltins}}]
         [=extended attribute=], then return true.
-    1.  Let |prototype| be |O|.\[[GetPrototypeOf]]().
+    1.  Let |prototype| be |propertyHolder|.\[[GetPrototypeOf]]().
     1.  While |prototype| is not null:
-        1.  If |prototype| is not a [=named properties object=],
-            and |prototype| has an own property named |P|, then return false.
+        1.  If |prototype| has an own property named |P|, then return false.
         1.  Set |prototype| to |prototype|.\[[GetPrototypeOf]]().
     1.  Return true.
 </div>


### PR DESCRIPTION
In particular, if a string is a supported property name as well as an own
property of the window or Window.prototype object, we don't need to block
that property from existing on the named properties object, since it will
be shadowed automatically.

Fixes #607.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/626.html" title="Last updated on Feb 20, 2019, 11:13 AM UTC (dcab4de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/626/7769c5f...Ms2ger:dcab4de.html" title="Last updated on Feb 20, 2019, 11:13 AM UTC (dcab4de)">Diff</a>