### PR TITLE
fix: Remove raw percentage character from ID

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -89,7 +89,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: %Array.prototype%; url: sec-properties-of-the-array-prototype-object
         text: %Error.prototype%; url: sec-properties-of-the-error-prototype-object
         text: %Function.prototype%; url: sec-properties-of-the-function-prototype-object
-        text: %IteratorPrototype%; url: sec-%iteratorprototype%-object
+        text: %IteratorPrototype%; url: sec-iteratorprototype-object
         text: %Map.prototype%; url: sec-properties-of-the-map-prototype-object
         text: %Object.prototype%; url: sec-properties-of-the-object-prototype-object
         text: %Promise%; url: sec-promise-constructor


### PR DESCRIPTION
Came across this trying to run some HTML validation upstream in the Bikeshed repo