### PR TITLE
Fix `indent_size` in `.editorconfig` for Bikeshes files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ max_line_length = 100
 indent_style = tab
 
 [*.bs]
-indent_size = 1
+indent_size = 4
 
 [*.py]
 indent_size = 4


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

**WebIDL** uses 4 spaces for indentation in **Bikeshed** source files.

Corresponding spec‑factory change: <https://github.com/whatwg/spec-factory/pull/34>

---

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
