### PR TITLE
Editorial: Fix typo in `bigint` column in distinguishability table

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3558,7 +3558,7 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td>
-            <td>
+            <td>(b)
             <td>●
             <td>●
             <td>●
@@ -3571,7 +3571,7 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
-            <td>(b)
+            <td>
             <td>●
             <td>●
             <td>●


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Fixes <https://github.com/whatwg/webidl/issues/1010>

---

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1043.html" title="Last updated on Oct 12, 2021, 12:33 PM UTC (d0b3025)">Preview</a> | <a href="https://whatpr.org/webidl/1043/1aa9e49...d0b3025.html" title="Last updated on Oct 12, 2021, 12:33 PM UTC (d0b3025)">Diff</a>