### PR TITLE
Use [=tuple=] instead of [=pair=]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4259,7 +4259,7 @@ iteration</dfn> value to signal the end of the iteration, or resolves with one o
 : for [=value asynchronously iterable declarations=]:
 ::  a value of the type given in the declaration;
 : for [=pair asynchronously iterable declarations=]:
-::  a [=pair=] containing a value of the first type given in the declaration, and a value of the second type given in the declaration.
+::  a [=tuple=] containing a value of the first type given in the declaration, and a value of the second type given in the declaration.
 
 The prose may also define an <dfn export>asynchronous iterator return</dfn> algorithm. This
 algorithm receives the instance of the [=interface=] that is being iterated, the async iterator


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Fixes #1057


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1058.html" title="Last updated on Nov 2, 2021, 10:15 PM UTC (1a414f2)">Preview</a> | <a href="https://whatpr.org/webidl/1058/59dae6f...1a414f2.html" title="Last updated on Nov 2, 2021, 10:15 PM UTC (1a414f2)">Diff</a>