### PR TITLE
Editorial: use cite element in IPR section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15061,9 +15061,9 @@ The following conformance classes are defined by this specification:
     language binding.
 
 
-<p boilerplate=ipr>This Living Standard includes material copied from W3C’s
-<a href=https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/>WebIDL [sic] Level 1</a>, which is
-available under the
+<p boilerplate=ipr>This Living Standard includes material copied from W3C's
+<a href=https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/><cite>WebIDL [sic] Level 1</cite></a>,
+which is available under the
 <a href=https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document>W3C Software and Document License</a>.
 
 


### PR DESCRIPTION
(If this reminds you of the FS PR, it's because I used copy-and-paste.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1076.html" title="Last updated on Dec 13, 2021, 1:29 PM UTC (cad705c)">Preview</a> | <a href="https://whatpr.org/webidl/1076/0105032...cad705c.html" title="Last updated on Dec 13, 2021, 1:29 PM UTC (cad705c)">Diff</a>