### PR TITLE
Fix distinguishability for bigint and numeric types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3537,7 +3537,7 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td>
-            <td>
+            <td>(b)
             <td>●
             <td>●
             <td>●
@@ -3550,7 +3550,7 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
-            <td>(b)
+            <td>
             <td>●
             <td>●
             <td>●


### PR DESCRIPTION
Closes #1010. Closes #1043 by superseding it (since we cannot currently accept pseudonymous contributions 😢).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1082.html" title="Last updated on Jan 18, 2022, 10:39 PM UTC (61d95fe)">Preview</a> | <a href="https://whatpr.org/webidl/1082/d8b9790...61d95fe.html" title="Last updated on Jan 18, 2022, 10:39 PM UTC (61d95fe)">Diff</a>