### PR TITLE
Introduce "mark as handled" for promises

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8390,7 +8390,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
         |newCapability|).
 
     Note: This algorithm will behave in a very similar way to the
-    {{%Promise.prototype.then%|Promise.then()}} method.
+    {{%Promise.prototype.then%|promise.then()}} method.
     In particular, if the steps return a value of type |U| or
     <code><a interface>Promise</a>&lt;|U|&gt;</code>, this algorithm returns a
     <code><a interface>Promise</a>&lt;|U|&gt;</code> as well.
@@ -8465,11 +8465,24 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
         1.  [=Reject=] |promise| with |reason|.
     1.  [=Wait for all=] with |promises|, given |successSteps| and |failureSteps|.
     1.  Return |promise|.
+
+    <p class="note">This definition is useful when you wish to aggregate the results of multiple
+    promises, and then produce another promise from them, in the same way that
+    {{Promise/all()|Promise.all()}} functions for JavaScript code. If you do not need to produce
+    another promise, then [=waiting for all=] is likely better.
 </div>
 
-This phrase is useful when you wish to aggregate the results of multiple promises, and then produce
-another promise from them, in the same way that {{Promise/all()|Promise.all()}} functions for
-JavaScript code.
+<div algorithm>
+    To <dfn export lt="mark a promise as handled|mark as handled">mark as handled</dfn> a
+    <code><a interface>Promise</a>&lt;<var ignore>T</var>&gt;</code> |promise|, set
+    |promise|.\[[Promise]].\[[PromiseIsHandled]] to true.
+
+    <p class="note">This definition is useful for promises which you expect rejections to often be
+    ignored; it ensures such promises do not cause {{Window/unhandledrejection}} events. The most
+    common use case is for promise properties, which the web developer might or might not consult.
+    An example is the {{WritableStreamDefaultWriter/closed|writableStreamWriter.closed}} promise,
+    which is [=marked as handled=] immediately after it is [=rejected=].
+</div>
 
 
 <h5 id="es-promise-examples">Examples</h5>

--- a/index.bs
+++ b/index.bs
@@ -8477,11 +8477,10 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
     <code><a interface>Promise</a>&lt;<var ignore>T</var>&gt;</code> |promise|, set
     |promise|.\[[Promise]].\[[PromiseIsHandled]] to true.
 
-    <p class="note">This definition is useful for promises which you expect rejections to often be
-    ignored; it ensures such promises do not cause {{Window/unhandledrejection}} events. The most
+    <p class="note">This definition is useful for promises for which you expect rejections to often
+    be ignored; it ensures such promises do not cause {{Window/unhandledrejection}} events. The most
     common use case is for promise properties, which the web developer might or might not consult.
-    An example is the {{WritableStreamDefaultWriter/closed|writableStreamWriter.closed}} promise,
-    which is [=marked as handled=] immediately after it is [=rejected=].
+    An example is the {{WritableStreamDefaultWriter/closed|writableStreamWriter.closed}} promise.
 </div>
 
 


### PR DESCRIPTION
This helps specifications avoid reaching into internal slots. Closes #829.

Also includes some editorial touchups to nearby promise definitions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1090.html" title="Last updated on Feb 2, 2022, 10:17 PM UTC (c930213)">Preview</a> | <a href="https://whatpr.org/webidl/1090/ae0de45...c930213.html" title="Last updated on Feb 2, 2022, 10:17 PM UTC (c930213)">Diff</a>