### PR TITLE
Editorial: Completion reform for ECMAScript AOs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7133,7 +7133,7 @@ to its caller, and so on.
         Consider the following algorithm:
 
         1.  Let |x| be the ECMAScript value passed in to this algorithm.
-        1.  Let |y| be the result of calling <a abstract-op>ToString</a>(|x|).
+        1.  Let |y| be the result of calling [=?=] <a abstract-op>ToString</a>(|x|).
         1.  Return |y|.
     </div>
 
@@ -7721,7 +7721,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     1.  If |V| is <emu-val>null</emu-val> and the conversion is to an IDL type
         [=extended attribute associated with|associated with=] the [{{LegacyNullToEmptyString}}] extended
         attribute, then return the {{DOMString}} value that represents the empty string.
-    1.  Let |x| be <a abstract-op>ToString</a>(|V|).
+    1.  Let |x| be [=?=] <a abstract-op>ToString</a>(|V|).
     1.  Return the IDL {{DOMString}} value that represents the same sequence of code units as the one the ECMAScript String value |x| represents.
 </div>
 
@@ -7741,7 +7741,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{ByteString}} value by running the following algorithm:
 
-    1.  Let |x| be <a abstract-op>ToString</a>(|V|).
+    1.  Let |x| be [=?=] <a abstract-op>ToString</a>(|V|).
     1.  If the value of any [=ECMAScript String/element=]
         of |x| is greater than 255, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return an IDL {{ByteString}} value
@@ -7946,7 +7946,7 @@ values.
     to an IDL [=enumeration|enumeration type=] value as follows
     (where |E| is the [=enumeration=]):
 
-    1.  Let |S| be the result of calling <a abstract-op>ToString</a>(|V|).
+    1.  Let |S| be the result of calling [=?=] <a abstract-op>ToString</a>(|V|).
     1.  If |S| is not one of |E|’s [=enumeration values=],
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the enumeration value of type |E| that is equal to |S|.
@@ -8072,8 +8072,8 @@ ECMAScript Array values.
         1.  Let |V| be the value in |S| at index |i|.
         1.  Let |E| be the result of [=converted to an ECMAScript value|converting=]
             |V| to an ECMAScript value.
-        1.  Let |P| be the result of calling <a abstract-op>ToString</a>(|i|).
-        1.  Call <a abstract-op>CreateDataProperty</a>(|A|, |P|, |E|).
+        1.  Let |P| be the result of calling [=?=] <a abstract-op>ToString</a>(|i|).
+        1.  Call [=?=] <a abstract-op>CreateDataProperty</a>(|A|, |P|, |E|).
         1.  Set |i| to |i| + 1.
     1.  Return |A|.
 </div>
@@ -9095,7 +9095,7 @@ Array object references.
     1.  Let |array| be the result of
         [=converted to an ECMAScript value|converting=]
         the sequence of values of type |T| to an ECMAScript value.
-    1.  Perform <a abstract-op>SetIntegrityLevel</a>(|array|, "<code>frozen</code>").
+    1.  Perform [=?=] <a abstract-op>SetIntegrityLevel</a>(|array|, "<code>frozen</code>").
     1.  Return |array|.
 </div>
 
@@ -12284,7 +12284,8 @@ then there must exist a property with the following characteristics:
 
         The value of the property is a [=built-in function object=], which behaves as follows:
 
-        1.  Let |O| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
+        1.  Let |thisValue| be the <emu-val>this</emu-val> value.
+        1.  Let |O| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
         1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
@@ -12335,7 +12336,8 @@ The location of the property is determined as follows:
     then the [=function object=] is a [=built-in function object=] that,
     when invoked, must behave as follows:
 
-    1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
+    1.  Let |thisValue| be the <emu-val>this</emu-val> value.
+    1.  Let |object| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
     1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
@@ -12347,10 +12349,10 @@ The location of the property is determined as follows:
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If the interface has a [=maplike declaration=], then:
         1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|.
-        1.  Return <a abstract-op>CreateMapIterator</a>(|backing|, "<code>key+value</code>").
+        1.  Return [=!=] <a abstract-op>CreateMapIterator</a>(|backing|, "<code>key+value</code>").
     1.  Otherwise:
         1.  Let |backing| be the value of the \[[BackingSet]] [=internal slot=] of |object|.
-        1.  Return <a abstract-op>CreateSetIterator</a>(|backing|, "<code>value</code>").
+        1.  Return [=!=] <a abstract-op>CreateSetIterator</a>(|backing|, "<code>value</code>").
 </div>
 
 The value of the {{@@iterator}} [=function object=]’s <code class="idl">length</code>
@@ -12381,7 +12383,8 @@ The location of the property is determined as follows:
     If the interface has a [=maplike declaration=] or [=setlike declaration=] then
     the method, when invoked, must behave as follows:
 
-    1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
+    1.  Let |thisValue| be the <emu-val>this</emu-val> value.
+    1.  Let |object| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
     1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
@@ -12576,9 +12579,9 @@ must be {{%IteratorPrototype%}}.
                 1.  Let |idlValue| be |pair|’s [=value pair/value=].
                 1.  Let |key| be the result of [=converted to an ECMAScript value|converting=] |idlKey| to an ECMAScript value.
                 1.  Let |value| be the result of [=converted to an ECMAScript value|converting=] |idlValue| to an ECMAScript value.
-                1.  Let |array| be the result of performing [$ArrayCreate$](2).
-                1.  Call [$CreateDataProperty$](|array|, "<code>0</code>", |key|).
-                1.  Call [$CreateDataProperty$](|array|, "<code>1</code>", |value|).
+                1.  Let |array| be [=!=] [$ArrayCreate$](2).
+                1.  Call [=!=] [$CreateDataProperty$](|array|, "<code>0</code>", |key|).
+                1.  Call [=!=] [$CreateDataProperty$](|array|, "<code>1</code>", |value|).
                 1.  |result| is |array|.
         </dl>
     1.  Return [$CreateIterResultObject$](|result|, <emu-val>false</emu-val>).
@@ -12592,7 +12595,8 @@ must be {{%IteratorPrototype%}}.
 
     1.  Let |interface| be the [=interface=] for which the
         [=iterator prototype object=] exists.
-    1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
+    1.  Let |thisValue| be the <emu-val>this</emu-val> value.
+    1.  Let |object| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
     1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
@@ -12773,8 +12777,8 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
 
     1.  Let |thisValidationPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
 
-    1.  Let |object| be the result of calling [$ToObject$] on the
-        <emu-val>this</emu-val> value.
+    1.  Let |thisValue| be the <emu-val>this</emu-val> value.
+    1.  Let |object| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
 
     1.  [$IfAbruptRejectPromise$](|object|, |thisValidationPromiseCapability|).
 
@@ -12863,8 +12867,8 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
 
     1.  Let |returnPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
 
-    1.  Let |object| be the result of calling [$ToObject$] on the
-        <emu-val>this</emu-val> value.
+    1.  Let |thisValue| be the <emu-val>this</emu-val> value.
+    1.  Let |object| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
 
     1.  [$IfAbruptRejectPromise$](|object|, |returnPromiseCapability|).
 
@@ -12986,7 +12990,7 @@ with the following characteristics:
             *   the type "<code>getter</code>".
         1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
-        1.  Return <a abstract-op>Get</a>(|map|, "<code>size</code>").
+        1.  Return [=!=] <a abstract-op>Get</a>(|map|, "<code>size</code>").
     </div>
 
     The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
@@ -13368,7 +13372,7 @@ the Realm given as an argument.
         1.  Assert: [$IsCallable$](|newTarget|) is true.
         1.  Let |prototype| be [=?=] [$Get$](|newTarget|, "prototype").
         1.  If [$Type$](|prototype|) is not Object, then:
-            1.  Let |targetRealm| be [$GetFunctionRealm$](|newTarget|).
+            1.  Let |targetRealm| be [=?=] [$GetFunctionRealm$](|newTarget|).
             1.  Set |prototype| to the [=interface prototype object=] for |interface| in
                 |targetRealm|.
     1.  Let |instance| be [$MakeBasicObject$](
@@ -13556,7 +13560,7 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
     The \[[GetOwnProperty]] internal method of every [=legacy platform object=] |O|
     must behave as follows when called with property name |P|:
 
-    1. Return <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>false</emu-val>).
+    1. Return [=?=] <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>false</emu-val>).
 </div>
 
 
@@ -13577,7 +13581,7 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
             and <a abstract-op>Type</a>(|P|) is String, then:
             1.  [=Invoke the named property setter=] on |O| with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
-    1.  Let |ownDesc| be <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>true</emu-val>).
+    1.  Let |ownDesc| be [=?=] <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>true</emu-val>).
     1.  Perform [=?=] <a abstract-op>OrdinarySetWithOwnDescriptor</a>(|O|, |P|, |V|, |Receiver|, |ownDesc|).
 </div>
 
@@ -13619,7 +13623,7 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
                 1.  Return <emu-val>true</emu-val>.
     1.  If |O| does not implement an [=interface=] with the [{{Global}}] [=extended attribute=],
         then set |Desc|.\[[Configurable]] to <emu-val>true</emu-val>.
-    1.  Return <a abstract-op>OrdinaryDefineOwnProperty</a>(|O|, |P|, |Desc|).
+    1.  Return [=?=] <a abstract-op>OrdinaryDefineOwnProperty</a>(|O|, |P|, |Desc|).
 </div>
 
 
@@ -13632,7 +13636,7 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
 
     1.  If |O| [=support indexed properties|supports indexed properties=] and
         |P| [=is an array index=], then:
-        1.  Let |index| be the result of calling <a abstract-op>ToUint32</a>(|P|).
+        1.  Let |index| be the result of calling [=!=] <a abstract-op>ToUint32</a>(|P|).
         1.  If |index| is not a [=supported property indices|supported property index=], then return <emu-val>true</emu-val>.
         1.  Return <emu-val>false</emu-val>.
     1.  If |O| [=support named properties|supports named properties=],
@@ -13768,7 +13772,7 @@ internal method as follows.
     To <dfn id="invoke-indexed-setter" oldids="invoking-indexed-setter" export lt="invoke the indexed property setter">invoke an indexed property setter</dfn>
     on a [=platform object=] |O| with property name |P| and ECMAScript value |V|, the following steps must be performed:
 
-    1.  Let |index| be the result of calling <a abstract-op>ToUint32</a>(|P|).
+    1.  Let |index| be the result of calling [=?=] <a abstract-op>ToUint32</a>(|P|).
     1.  Let |creating| be true if |index| is not a [=supported property indices|supported property index=],
         and false otherwise.
     1.  Let |operation| be the operation used to declare the indexed property setter.
@@ -13813,7 +13817,7 @@ internal method as follows.
 
     1.  If |O| [=support indexed properties|supports indexed properties=]
         and |P| [=is an array index=], then:
-        1.  Let |index| be the result of calling <a abstract-op>ToUint32</a>(|P|).
+        1.  Let |index| be the result of calling [=!=] <a abstract-op>ToUint32</a>(|P|).
         1.  If |index| is a [=supported property indices|supported property index=], then:
             1.  Let |operation| be the operation used to declare the indexed property getter.
             1.  Let |value| be an uninitialized variable.
@@ -14176,8 +14180,8 @@ the special value “missing”, which represents a missing optional argument.
             to |getResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |X| to |getResult|.\[[Value]].
         1.  If <a abstract-op>IsCallable</a>(|X|) is <emu-val>false</emu-val>,
-            then set |completion| to a new <a abstract-op>Completion</a>{\[[Type]]: throw, \[[Value]]: a
-            newly created {{ECMAScript/TypeError}} object, \[[Target]]: empty}, and jump
+            then set |completion| to [=Completion Record=] { \[[Type]]: throw, \[[Value]]: a
+            newly created {{ECMAScript/TypeError}} object, \[[Target]]: empty }, and jump
             to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |thisArg| to |O| (overriding the provided value).
     1.  Let |esArgs| be the result of [=Web IDL arguments list/converting=] |args| to an ECMAScript

--- a/index.bs
+++ b/index.bs
@@ -14175,7 +14175,7 @@ the special value “missing”, which represents a missing optional argument.
     1.  [=Prepare to run a callback=] with |stored settings|.
     1.  Let |X| be |O|.
     1.  If <a abstract-op>IsCallable</a>(|O|) is false, then:
-        1.  Let |getResult| be <a abstract-op>Get</a>(|O|, |opName|).
+        1.  Let |getResult| be <a abstract-op>Completion(<a abstract-op>Get</a>(|O|, |opName|)).
         1.  If |getResult| is an [=abrupt completion=], set |completion|
             to |getResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |X| to |getResult|.\[[Value]].
@@ -14188,7 +14188,7 @@ the special value “missing”, which represents a missing optional argument.
         arguments list. If this throws an exception, set |completion| to the completion value
         representing the thrown exception and jump to the step labeled
         <a href="#call-user-object-operation-return"><i>return</i></a>.
-    1.  Let |callResult| be <a abstract-op>Call</a>(|X|, |thisArg|, |esArgs|).
+    1.  Let |callResult| be <a abstract-op>Completion(<a abstract-op>Call</a>(|X|, |thisArg|, |esArgs|)).
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
@@ -14276,7 +14276,7 @@ described in the previous section).
         arguments list. If this throws an exception, set |completion| to the completion value
         representing the thrown exception and jump to the step labeled
         <a href="#invoke-return"><i>return</i></a>.
-    1.  Let |callResult| be <a abstract-op>Call</a>(|F|, |thisArg|, |esArgs|).
+    1.  Let |callResult| be <a abstract-op>Completion(<a abstract-op>Call</a>(|F|, |thisArg|, |esArgs|)).
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
@@ -14318,7 +14318,7 @@ a return type that is a [=promise type=].
         arguments list. If this throws an exception, set |completion| to the completion value
         representing the thrown exception and jump to the step labeled
         <a href="#construct-return"><i>return</i></a>.
-    1.  Let |callResult| be <a abstract-op>Construct</a>(|F|, |esArgs|).
+    1.  Let |callResult| be <a abstract-op>Completion(<a abstract-op>Construct</a>(|F|, |esArgs|)).
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#construct-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]

--- a/index.bs
+++ b/index.bs
@@ -7529,7 +7529,7 @@ In effect, where <var ignore>x</var> is a Number value,
         the [{{EnforceRange}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
             then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-        1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
+        1.  Set |x| to <a abstract-op>IntegerPart</a>(|x|).
         1.  If |x| &lt; |lowerBound| or |x| &gt; |upperBound|,
             then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Return |x|.
@@ -7542,7 +7542,7 @@ In effect, where <var ignore>x</var> is a Number value,
         1.  Return |x|.
     1.  If |x| is <emu-val>NaN</emu-val>, +0, +∞, or −∞,
         then return +0.
-    1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
+    1.  Set |x| to <a abstract-op>IntegerPart</a>(|x|).
     1.  Set |x| to |x| [=modulo=] 2<sup>|bitLength|</sup>.
     1.  If |signedness| is "<code>signed</code>" and |x| ≥ 2<sup>|bitLength| − 1</sup>,
         then return |x| − 2<sup>|bitLength|</sup>.
@@ -7918,7 +7918,7 @@ up on the ECMAScript object are not necessarily the same as the object’s prope
     to an ECMAScript Object value by
     running the following algorithm (where |D| is the [=dictionary=]):
 
-    1.  Let |O| be [=!=] [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
+    1.  Let |O| be [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|’s [=inherited dictionaries=],
         in order from least to most derived.
     1.  For each dictionary |dictionary| in |dictionaries|, in order:
@@ -8215,7 +8215,7 @@ ECMAScript Object values.
     [=converted to an ECMAScript value|converted=]
     to an ECMAScript value as follows:
 
-    1.  Let |result| be [=!=] [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
+    1.  Let |result| be [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
     1.  [=map/For each=] |key| → |value| of |D|:
         1.  Let |esKey| be |key| [=converted to an ECMAScript value=].
         1.  Let |esValue| be |value| [=converted to an ECMAScript value=].
@@ -8372,7 +8372,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
             the result of performing them, given |value| if |T| is not {{undefined}}. Otherwise, let
             |result| be |value|.
         1.  Return |result|, [=converted to an ECMAScript value=].
-    1.  Let |onFulfilled| be [=!=] [$CreateBuiltinFunction$](|onFulfilledSteps|, « »):
+    1.  Let |onFulfilled| be [$CreateBuiltinFunction$](|onFulfilledSteps|, « »):
     1.  Let |onRejectedSteps| be the following steps given argument |R|:
         1.  Let |reason| be the result of [=converted to an IDL value|converting=]
             |R| to an IDL value of type {{any}}.
@@ -8380,13 +8380,13 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
             the result of performing them, given |reason|. Otherwise, let |result| be
             [=a promise rejected with=] |reason|.
         1.  Return |result|, [=converted to an ECMAScript value=].
-    1.  Let |onRejected| be [=!=] [$CreateBuiltinFunction$](|onRejectedSteps|, « »):
+    1.  Let |onRejected| be [$CreateBuiltinFunction$](|onRejectedSteps|, « »):
     1.  Let |constructor| be |promise|.\[[Promise]].\[[Realm]].\[[Intrinsics]].[[{{%Promise%}}]].
     1.  Let |newCapability| be [=?=] [$NewPromiseCapability$](|constructor|).
 
         Note: Not all callers will use the returned {{Promise}}. Implementations might wish to
         avoid creating |newCapability| in those cases.
-    1.  Return [=!=] [$PerformPromiseThen$](|promise|.\[[Promise]], |onFulfilled|, |onRejected|,
+    1.  Return [$PerformPromiseThen$](|promise|.\[[Promise]], |onFulfilled|, |onRejected|,
         |newCapability|).
 
     Note: This algorithm will behave in a very similar way to the
@@ -8431,7 +8431,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
         1.  If |rejected| is true, abort these steps.
         1.  Set |rejected| to true.
         1.  Perform |failureSteps| given |arg|.
-    1.  Let |rejectionHandler| be [=!=] [$CreateBuiltinFunction$](|rejectionHandlerSteps|, « »):
+    1.  Let |rejectionHandler| be [$CreateBuiltinFunction$](|rejectionHandlerSteps|, « »):
     1.  Let |total| be |promises|'s [=list/size=].
     1.  If |total| is 0, then:
         1.  [=Queue a microtask=] to perform |successSteps| given « ».
@@ -8444,7 +8444,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
             1.  Set |result|[|promiseIndex|] to |arg|.
             1.  Set |fullfilledCount| to |fullfilledCount| + 1.
             1.  If |fullfilledCount| equals |total|, then perform |successSteps| given |result|.
-        1.  Let |fulfillmentHandler| be [=!=] [$CreateBuiltinFunction$](|fulfillmentHandler|, « »):
+        1.  Let |fulfillmentHandler| be [$CreateBuiltinFunction$](|fulfillmentHandler|, « »):
         1.  Perform [$PerformPromiseThen$](|promise|, |fulfillmentHandler|, |rejectionHandler|).
         1.  Set |index| to |index| + 1.
 </div>
@@ -8943,11 +8943,11 @@ a reference to the same object that the IDL value represents.
         1.  Assert: |esBufferSource| is an {{ECMAScript/ArrayBuffer}} or
             {{ECMAScript/SharedArrayBuffer}} object.
         1.  Set |length| to |esBufferSource|.\[[ArrayBufferByteLength]].
-    1.  If [=!=] [$IsDetachedBuffer$](|esArrayBuffer|) is true, then return the empty
+    1.  If [$IsDetachedBuffer$](|esArrayBuffer|) is true, then return the empty
         [=byte sequence=].
     1.  Let |bytes| be a new [=byte sequence=] of [=byte sequence/length=] equal to |length|.
     1.  For |i| in [=the range=] |offset| to |offset| + |length| &minus; 1, inclusive, set
-        |bytes|[|i| &minus; |offset|] to [=!=] [$GetValueFromBuffer$](|esArrayBuffer|, |i|, Uint8,
+        |bytes|[|i| &minus; |offset|] to [$GetValueFromBuffer$](|esArrayBuffer|, |i|, Uint8,
         true, Unordered).
     1.  Return |bytes|.
 </div>
@@ -8984,7 +8984,7 @@ a reference to the same object that the IDL value represents.
     1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |esArrayBuffer|.\[[ArrayBufferByteLength]]
         &minus; |startingOffset|.
     1.  For |i| in [=the range=] |startingOffset| to |startingOffset| + |bytes|'s [=byte
-        sequence/length=] &minus; 1, inclusive, perform [=!=] [$SetValueInBuffer$](|esArrayBuffer|,
+        sequence/length=] &minus; 1, inclusive, perform [$SetValueInBuffer$](|esArrayBuffer|,
         |i|, Uint8, |bytes|[|i| - |startingOffset|], true, Unordered).
 </div>
 
@@ -9024,7 +9024,7 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |esArrayBuffer| be the result of [=converted to an ECMAScript value|converting=]
         |arrayBuffer| to an ECMAScript value.
-    1.  Assert: [=!=] [$IsSharedArrayBuffer$](|esArrayBuffer|) is false.
+    1.  Assert: [$IsSharedArrayBuffer$](|esArrayBuffer|) is false.
     1.  Perform [=?=] [$DetachArrayBuffer$](|esArrayBuffer|).
 
     <p class="note">This will throw an exception if |esArrayBuffer| has an \[[ArrayBufferDetachKey]]
@@ -9042,7 +9042,7 @@ a reference to the same object that the IDL value represents.
         |bufferSource| to an ECMAScript value.
     1.  If |esArrayBuffer| has a \[[ViewedArrayBuffer]] internal slot, then set |esArrayBuffer| to
         |esArrayBuffer|.\[[ViewedArrayBuffer]].
-    1.  Return [=!=] [$IsDetachedBuffer$](|esArrayBuffer|).
+    1.  Return [$IsDetachedBuffer$](|esArrayBuffer|).
 </div>
 
 <div algorithm>
@@ -9051,8 +9051,8 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |esArrayBuffer| be the result of [=converted to an ECMAScript value|converting=]
         |arrayBuffer| to an ECMAScript value.
-    1.  Assert: [=!=] [$IsSharedArrayBuffer$](|esArrayBuffer|) is false.
-    1.  Assert: [=!=] [$IsDetachedBuffer$](|esArrayBuffer|) is false.
+    1.  Assert: [$IsSharedArrayBuffer$](|esArrayBuffer|) is false.
+    1.  Assert: [$IsDetachedBuffer$](|esArrayBuffer|) is false.
     1.  Let |arrayBufferData| be |esArrayBuffer|.\[[ArrayBufferData]].
     1.  Let |arrayBufferByteLength| be |esArrayBuffer|.\[[ArrayBufferByteLength]].
     1.  Perform [=?=] [$DetachArrayBuffer$](|esArrayBuffer|).
@@ -11478,9 +11478,9 @@ default interfaces do not have such steps.
     1.  Let |constructorProto| be |realm|.\[[Intrinsics]].[[{{%Function.prototype%}}]].
     1.  If |I| inherits from some other interface |P|,
         then set |constructorProto| to the [=interface object=] of |P| in |realm|.
-    1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « \[[Unforgeables]] »,
+    1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « \[[Unforgeables]] »,
         |realm|, |constructorProto|).
-    1.  Let |unforgeables| be [=!=] [$OrdinaryObjectCreate$](<emu-val>null</emu-val>).
+    1.  Let |unforgeables| be [$OrdinaryObjectCreate$](<emu-val>null</emu-val>).
     1.  [=Define the unforgeable regular operations=] of |I| on |unforgeables|, given |realm|.
     1.  [=Define the unforgeable regular attributes=] of |I| on |unforgeables|, given |realm|.
     1.  Set |F|.\[[Unforgeables]] to |unforgeables|.
@@ -11489,14 +11489,14 @@ default interfaces do not have such steps.
         of an interface with an unforgeable member use the same JavaScript function objects for
         [=attribute getters=], [=attribute setters=] and [=creating an operation
         function|operation functions=].
-    1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
+    1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  Let |length| be 0.
     1.  If |I| was declared with a [=constructor operation=], then
         1.  [=Compute the effective overload set=] for constructors with [=identifier=] |id| on
             [=interface=] |I| and with argument count 0, and let |S| be the result.
         1.  Set |length| to the length of the
             shortest argument list of the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).
+    1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, |length|).
     1.  Let |proto| be the result of [=create an interface prototype object|creating an interface
         prototype object=] of [=interface=] |I| in |realm|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>prototype</code>",
@@ -11542,12 +11542,12 @@ implement the interface on which the
         1.  Assert: |O| is an object that [=implements=] |I|.
         1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
-    1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
-    1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
+    1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
+    1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  [=Compute the effective overload set=] for legacy factory functions with [=identifier=] |id|
         on [=interface=] |I| and with argument count 0, and let |S| be the result.
     1.  Let |length| be the length of the shortest argument list of the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).
+    1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, |length|).
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I| in |realm|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>prototype</code>",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
@@ -11583,20 +11583,20 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
     1.  If |interface| is declared with the [{{Global}}] [=extended attribute=], or
         |interface| is in the set of [=inherited interfaces=] of an interface
         that is declared with the [{{Global}}] [=extended attribute=], then:
-        1.  Set |interfaceProtoObj| to [=!=] [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
+        1.  Set |interfaceProtoObj| to [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
         1.  Set |interfaceProtoObj|.\[[Prototype]] to |proto|.
         1.  Set the internal methods of |interfaceProtoObj|
             which are specific to [=immutable prototype exotic objects=]
             to the definitions specified in
             [=ECMA-262 Immutable prototype exotic objects=].
-    1.  Otherwise, set |interfaceProtoObj| to [=!=] [$OrdinaryObjectCreate$](|proto|).
+    1.  Otherwise, set |interfaceProtoObj| to [$OrdinaryObjectCreate$](|proto|).
     1.  If |interface| has any [=member=] declared with the [{{Unscopable}}] [=extended attribute=],
         then:
 
         Issue: Should an {{@@unscopables}} property also be defined if |interface| is
         declared with the [{{Global}}] [=extended attribute=]?
         This is discussed in <a href="https://github.com/heycam/webidl/issues/544">issue #544</a>.
-        1.  Let |unscopableObject| be [=!=] [$OrdinaryObjectCreate$](<emu-val>null</emu-val>).
+        1.  Let |unscopableObject| be [$OrdinaryObjectCreate$](<emu-val>null</emu-val>).
         1.  [=list/For each=] [=exposed=] [=member=] |member| of |interface|
             that is declared with the [{{Unscopable}}] [=extended attribute=]:
             1.  Let |id| be |member|'s [=identifier=].
@@ -11680,7 +11680,7 @@ for that interface on which named properties are exposed.
     1.  If |interface| is declared to inherit from another interface,
         then set |proto| to the [=interface prototype object=] in |realm| for the [=inherited interface=].
     1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]].
-    1.  Let |obj| be [=!=] [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
+    1.  Let |obj| be [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
     1.  Set |obj|.\[[GetOwnProperty]] as specified in [[#named-properties-object-getownproperty]].
     1.  Set |obj|.\[[DefineOwnProperty]] as specified in [[#named-properties-object-defineownproperty]].
     1.  Set |obj|.\[[Delete]] as specified in [[#named-properties-object-delete]].
@@ -11896,10 +11896,10 @@ in which case they are exposed on every object that [=implements=] the interface
         1.  If |attribute|'s type is a [=promise type=], then return
             [=!=] <a abstract-op>Call</a>({{%Promise.reject%}}, {{%Promise%}}, «|E|»).
         1.  Otherwise, end these steps and allow the exception to propagate.
-    1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
+    1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Let |name| be the string "<code>get </code>" prepended to |attribute|'s [=identifier=].
-    1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
-    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, 0).
+    1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |name|).
+    1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, 0).
     1.  Return |F|.
 
 </div>
@@ -11982,10 +11982,10 @@ in which case they are exposed on every object that [=implements=] the interface
         1.  Perform the [=setter steps=] of |attribute|,
             with |idlObject| as [=this=] and |idlValue| as [=the given value=].
         1.  Return <emu-val>undefined</emu-val>
-    1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
+    1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Let |name| be the string "<code>set </code>" prepended to |id|.
-    1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
-    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, 1).
+    1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |name|).
+    1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, 1).
     1. Return |F|.
 </div>
 
@@ -12100,13 +12100,13 @@ in which case they are exposed on every object that [=implements=] the interface
             that is a [=promise type=], then return
             [=!=] <a abstract-op>Call</a>({{%Promise.reject%}}, {{%Promise%}}, «|E|»).
         1.  Otherwise, end these steps and allow the exception to propagate.
-    1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
-    1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
+    1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
+    1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  [=Compute the effective overload set=]  for [=regular operations=] (if |op| is a regular
         operation) or for [=static operations=] (if |op| is a static operation) with [=identifier=]
         |id| on |target| and with argument count 0, and let |S| be the result.
     1.  Let |length| be the length of the shortest argument list in the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).
+    1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, |length|).
     1.  Return |F|.
 </div>
 
@@ -12146,7 +12146,7 @@ A [=regular operation=] that does not [=have default method steps=] must not be 
         for [=interface=] |I|.
     1.  Invoke [=collect attribute values of an inheritance stack=] given [=this=], |stack|, and
         |map|.
-    1.  Let |result| be [=!=] [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
+    1.  Let |result| be [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
     1.  [=map/For each=] |key| → |value| of |map|,
         1.  Let |k| be |key| [=converted to an ECMAScript value=].
         1.  Let |v| be |value| [=converted to an ECMAScript value=].
@@ -12431,7 +12431,7 @@ property is the String value "<code>forEach</code>".
     of [=interface=] |definition| on |target|, given [=Realm=] |realm|, run the following steps:
 
     1.  If |definition| has an [=indexed property getter=], then:
-        1.  Perform [=!=] [$CreateMethodProperty$](|target|, {{@@iterator}},
+        1.  Perform [$CreateMethodProperty$](|target|, {{@@iterator}},
             {{%Array.prototype.values%}}).
         1.  If |definition| has a [=value iterator=], then:
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>entries</code>",
@@ -12454,10 +12454,10 @@ property is the String value "<code>forEach</code>".
                     |esValue| as its [=default iterator object/target=], "<code>key+value</code>"
                     as its [=default iterator object/kind=], and [=default iterator object/index=]
                     set to 0.
-            1.  Let |F| be [=!=] [$CreateBuiltinFunction$](|steps|, « », |realm|).
-            1.  Perform [=!=] [$SetFunctionName$](|F|, "<code>entries</code>").
-            1.  Perform [=!=] [$SetFunctionLength$](|F|, 0).
-            1.  Perform [=!=] [$CreateMethodProperty$](|target|, {{@@iterator}}, |F|).
+            1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
+            1.  Perform [$SetFunctionName$](|F|, "<code>entries</code>").
+            1.  Perform [$SetFunctionLength$](|F|, 0).
+            1.  Perform [$CreateMethodProperty$](|target|, {{@@iterator}}, |F|).
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>entries</code>", |F|).
         1.  Define the <code class="idl">keys</code> method:
             1.  Let |steps| be the following series of steps:
@@ -12469,9 +12469,9 @@ property is the String value "<code>forEach</code>".
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>key</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
-            1.  Let |F| be [=!=] [$CreateBuiltinFunction$](|steps|, « », |realm|).
-            1.  Perform [=!=] [$SetFunctionName$](|F|, "<code>keys</code>").
-            1.  Perform [=!=] [$SetFunctionLength$](|F|, 0).
+            1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
+            1.  Perform [$SetFunctionName$](|F|, "<code>keys</code>").
+            1.  Perform [$SetFunctionLength$](|F|, 0).
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>keys</code>", |F|).
         1.  Define the <code class="idl">values</code> method:
             1.  Let |steps| be the following series of steps:
@@ -12483,9 +12483,9 @@ property is the String value "<code>forEach</code>".
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>value</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
-            1.  Let |F| be [=!=] [$CreateBuiltinFunction$](|steps|, « », |realm|).
-            1.  Perform [=!=] [$SetFunctionName$](|F|, "<code>values</code>").
-            1.  Perform [=!=] [$SetFunctionLength$](|F|, 0).
+            1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
+            1.  Perform [$SetFunctionName$](|F|, "<code>values</code>").
+            1.  Perform [$SetFunctionLength$](|F|, 0).
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>values</code>", |F|).
         1.  Define the <code class="idl">forEach</code> method:
             1.  Let |steps| be the following series of steps, given function argument values
@@ -12509,9 +12509,9 @@ property is the String value "<code>forEach</code>".
                     1.  Set |pairs| to |idlObject|'s current list of
                         [=value pairs to iterate over=]. (It might have changed.)
                     1.  Set |i| to |i| + 1.
-            1.  Let |F| be [=!=] [$CreateBuiltinFunction$](|steps|, « », |realm|).
-            1.  Perform [=!=] [$SetFunctionName$](|F|, "<code>forEach</code>").
-            1.  Perform [=!=] [$SetFunctionLength$](|F|, 1).
+            1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
+            1.  Perform [$SetFunctionName$](|F|, "<code>forEach</code>").
+            1.  Perform [$SetFunctionLength$](|F|, 1).
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>forEach</code>", |F|).
 </div>
 
@@ -12645,10 +12645,10 @@ and the string "<code> Iterator</code>".
             1.  Run the [=asynchronous iterator initialization steps=] for |definition| with
                 |idlObject|, |iterator|, and |idlArgs|, if any such steps exist.
             1.  Return |iterator|.
-        1.  Let |F| be [=!=] [$CreateBuiltinFunction$](|steps|, « », |realm|).
-        1.  Perform [=!=] [$SetFunctionName$](|F|, "<code>entries</code>").
-        1.  Perform [=!=] [$SetFunctionLength$](|F|, 0).
-        1.  Perform [=!=] [$CreateMethodProperty$](|target|, {{@@asyncIterator}}, |F|).
+        1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
+        1.  Perform [$SetFunctionName$](|F|, "<code>entries</code>").
+        1.  Perform [$SetFunctionLength$](|F|, 0).
+        1.  Perform [$CreateMethodProperty$](|target|, {{@@asyncIterator}}, |F|).
         1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>entries</code>", |F|).
     1.  If |definition| has a [=pair asynchronously iterable declaration=], then define the
         <code class="idl">keys</code> method:
@@ -12670,9 +12670,9 @@ and the string "<code> Iterator</code>".
             1.  Run the [=asynchronous iterator initialization steps=] for |definition| with
                 |idlObject|, |iterator|, and |idlArgs|, if any such steps exist.
             1.  Return |iterator|.
-        1.  Let |F| be [=!=] [$CreateBuiltinFunction$](|steps|, « », |realm|).
-        1.  Perform [=!=] [$SetFunctionName$](|F|, "<code>keys</code>").
-        1.  Perform [=!=] [$SetFunctionLength$](|F|, 0).
+        1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
+        1.  Perform [$SetFunctionName$](|F|, "<code>keys</code>").
+        1.  Perform [$SetFunctionLength$](|F|, 0).
         1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>keys</code>", |F|).
     1.  Define the <code class="idl">values</code>, and possibly {{@@asyncIterator}}, methods:
         1.  Let |steps| be the following series of steps, given function argument values |args|:
@@ -12693,9 +12693,9 @@ and the string "<code> Iterator</code>".
             1.  Run the [=asynchronous iterator initialization steps=] for |definition| with
                 |idlObject|, |iterator|, and |idlArgs|, if any such steps exist.
             1.  Return |iterator|.
-        1.  Let |F| be [=!=] [$CreateBuiltinFunction$](|steps|, « », |realm|).
-        1.  Perform [=!=] [$SetFunctionName$](|F|, "<code>values</code>").
-        1.  Perform [=!=] [$SetFunctionLength$](|F|, 0).
+        1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
+        1.  Perform [$SetFunctionName$](|F|, "<code>values</code>").
+        1.  Perform [$SetFunctionLength$](|F|, 0).
         1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>values</code>", |F|).
         1.  If |definition| has a [=value asynchronously iterable declaration=], then perform [=!=]
             [$CreateMethodProperty$](|target|, {{@@asyncIterator}}, |F|).
@@ -12811,7 +12811,7 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
                 null.
             1.  If |next| is [=end of iteration=], then:
                 1.  Set |object|'s [=default asynchronous iterator object/is finished=] to true.
-                1.  Return [=!=] [$CreateIterResultObject$](<emu-val>undefined</emu-val>,
+                1.  Return [$CreateIterResultObject$](<emu-val>undefined</emu-val>,
                     <emu-val>true</emu-val>).
             1.  Otherwise, if |interface| has a [=pair asynchronously iterable declaration=]:
                 1.  Assert: |next| is a [=value pair=].
@@ -12820,15 +12820,15 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
                 1.  Assert: |interface| has a [=value asynchronously iterable declaration=].
                 1.  Assert: |next| is a value of the type that appears in the declaration.
                 1.  Let |value| be |next|, [=converted to an ECMAScript value=].
-                1.  Return [=!=] [$CreateIterResultObject$](|value|, <emu-val>false</emu-val>).
-        1.  Let |onFulfilled| be [=!=] [$CreateBuiltinFunction$](|fulfillSteps|, « »).
+                1.  Return [$CreateIterResultObject$](|value|, <emu-val>false</emu-val>).
+        1.  Let |onFulfilled| be [$CreateBuiltinFunction$](|fulfillSteps|, « »).
         1.  Let |rejectSteps| be the following steps, given |reason|:
             1.  Set |object|'s [=default asynchronous iterator object/ongoing promise=] to
                 null.
             1.  Set |object|'s [=default asynchronous iterator object/is finished=] to true.
             1.  [=ECMAScript/Throw=] |reason|.
-        1.  Let |onRejected| be [=!=] [$CreateBuiltinFunction$](|rejectSteps|, « »).
-        1.  Perform [=!=] [$PerformPromiseThen$](|nextPromise|, |onFulfilled|, |onRejected|,
+        1.  Let |onRejected| be [$CreateBuiltinFunction$](|rejectSteps|, « »).
+        1.  Perform [$PerformPromiseThen$](|nextPromise|, |onFulfilled|, |onRejected|,
             |nextPromiseCapability|).
         1.  Return |nextPromiseCapability|.\[[Promise]].
 
@@ -12836,8 +12836,8 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
 
     1.  If |ongoingPromise| is not null, then:
         1.  Let |afterOngoingPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
-        1.  Let |onSettled| be [=!=] [$CreateBuiltinFunction$](|nextSteps|, « »).
-        1.  Perform [=!=] [$PerformPromiseThen$](|ongoingPromise|, |onSettled|, |onSettled|,
+        1.  Let |onSettled| be [$CreateBuiltinFunction$](|nextSteps|, « »).
+        1.  Perform [$PerformPromiseThen$](|ongoingPromise|, |onSettled|, |onSettled|,
             |afterOngoingPromiseCapability|).
         1.  Set |object|'s [=default asynchronous iterator object/ongoing promise=] to
             |afterOngoingPromiseCapability|.\[[Promise]].
@@ -12902,8 +12902,8 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
 
     1.  If |ongoingPromise| is not null, then:
         1.  Let |afterOngoingPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
-        1.  Let |onSettled| be [=!=] [$CreateBuiltinFunction$](|returnSteps|, « »).
-        1.  Perform [=!=] [$PerformPromiseThen$](|ongoingPromise|, |onSettled|, |onSettled|,
+        1.  Let |onSettled| be [$CreateBuiltinFunction$](|returnSteps|, « »).
+        1.  Perform [$PerformPromiseThen$](|ongoingPromise|, |onSettled|, |onSettled|,
             |afterOngoingPromiseCapability|).
         1.  Set |returnStepsPromise| to |afterOngoingPromiseCapability|.\[[Promise]].
 
@@ -12911,11 +12911,11 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
         1.  Set |returnStepsPromise| to the result of running |returnSteps|.
 
     1.  Let |fulfillSteps| be the following steps:
-        1.  Return [=!=] [$CreateIterResultObject$](|value|, <emu-val>true</emu-val>).
+        1.  Return [$CreateIterResultObject$](|value|, <emu-val>true</emu-val>).
 
-    1.  Let |onFulfilled| be [=!=] [$CreateBuiltinFunction$](|fulfillSteps|, « »).
+    1.  Let |onFulfilled| be [$CreateBuiltinFunction$](|fulfillSteps|, « »).
 
-    1.  Perform [=!=] [$PerformPromiseThen$](|returnStepsPromise|, |onFulfilled|,
+    1.  Perform [$PerformPromiseThen$](|returnStepsPromise|, |onFulfilled|,
         <emu-val>undefined</emu-val>, |returnPromiseCapability|).
 
     1.  Return |returnPromiseCapability|.\[[Promise]].
@@ -13371,7 +13371,7 @@ the Realm given as an argument.
             1.  Let |targetRealm| be [$GetFunctionRealm$](|newTarget|).
             1.  Set |prototype| to the [=interface prototype object=] for |interface| in
                 |targetRealm|.
-    1.  Let |instance| be [=!=] [$MakeBasicObject$](
+    1.  Let |instance| be [$MakeBasicObject$](
         « \[[Prototype]], \[[Extensible]], \[[Realm]], \[[PrimaryInterface]] »).
     1.  Set |instance|.\[[Realm]] to |realm|.
     1.  Set |instance|.\[[PrimaryInterface]] to |interface|.
@@ -13423,12 +13423,12 @@ the Realm given as an argument.
             1.  Let |id| be |interface|'s [=identifier=].
             1.  Let |interfaceObject| be the result of [=create an interface object|creating
                 an interface object=] for |interface| with |id| in |realm|.
-            1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
+            1.  Perform [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
             1.  If the |interface| is declared with a [{{LegacyWindowAlias}}] [=extended attribute=],
                 and |target| implements the {{Window}} [=interface=], then:
                 1.  [=list/iterate|For every=] [=LegacyWindowAlias identifier|identifier=] |id| in
                     [{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifier|identifiers=]:
-                    1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
+                    1.  Perform [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
         1.  If the |interface| is declared with a [{{LegacyFactoryFunction}}] [=extended attribute=],
             then:
             1.  [=list/iterate|For every=] [=LegacyFactoryFunction identifier|identifier=] |id| in
@@ -13436,18 +13436,18 @@ the Realm given as an argument.
                 1.  Let |legacyFactoryFunction| be the result of
                     [=create a legacy factory function|creating a legacy factory function=] with
                     |id| for |interface| in |realm|.
-                1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |legacyFactoryFunction|).
+                1.  Perform [$CreateMethodProperty$](|target|, |id|, |legacyFactoryFunction|).
     1.  [=list/iterate|For every=] [=callback interface=] |interface| that is [=exposed=] in
         |realm| and on which [=constants=] are defined:
         1.  Let |id| be |interface|'s [=identifier=].
         1.  Let |interfaceObject| be the result of [=create a legacy callback interface
             object|creating a legacy callback interface object=] for |interface| with |id| in |realm|.
-        1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
+        1.  Perform [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
     1.  [=list/iterate|For every=] [=namespace=] |namespace| that is [=exposed=] in
         |realm|:
         1.  Let |id| be |namespace|'s [=identifier=].
         1.  Let |namespaceObject| be the result of [=create a namespace object|creating a namespace object=] for |namespace| in |realm|.
-        1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |namespaceObject|).
+        1.  Perform [$CreateMethodProperty$](|target|, |id|, |namespaceObject|).
 </div>
 
 <div class="note">
@@ -13711,7 +13711,7 @@ internal method as follows.
     applied:
 
     1.  If <a abstract-op>Type</a>(|P|) is not String, then return <emu-val>false</emu-val>.
-    1.  Let |index| be [=!=] <a abstract-op>CanonicalNumericIndexString</a>(|P|).
+    1.  Let |index| be <a abstract-op>CanonicalNumericIndexString</a>(|P|).
     1.  If |index| is <emu-val>undefined</emu-val>, then return <emu-val>false</emu-val>.
     1.  If <a abstract-op>IsInteger</a>(|index|) is <emu-val>false</emu-val>,
         then return <emu-val>false</emu-val>.
@@ -13889,26 +13889,26 @@ those of normal <code>Array</code> instances:
     in a [=Realm=] |realm|, given Web IDL type |T| and algorithms |setAlgorithm| and |deleteAlgorithm|:
 
     1.  Let |innerArray| be [=!=] [$ArrayCreate$](0).
-    1.  Let |handler| be [=!=] [$OrdinaryObjectCreate$](<emu-val>null</emu-val>,
+    1.  Let |handler| be [$OrdinaryObjectCreate$](<emu-val>null</emu-val>,
         « \[[Type]], \[[SetAlgorithm]], \[[DeleteAlgorithm]], \[[BackingList]] »).
     1.  Set |handler|.\[[Type]] to |T|.
     1.  Set |handler|.\[[SetAlgorithm]] to |setAlgorithm|.
     1.  Set |handler|.\[[DeleteAlgorithm]] to |deleteAlgorithm|.
-    1.  Let |defineProperty| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-defineProperty]], « », |realm|).
+    1.  Let |defineProperty| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-defineProperty]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>defineProperty</code>", |defineProperty|).
-    1.  Let |deleteProperty| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-deleteProperty]], « », |realm|).
+    1.  Let |deleteProperty| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-deleteProperty]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>deleteProperty</code>", |deleteProperty|).
-    1.  Let |get| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-get]], « », |realm|).
+    1.  Let |get| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-get]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>get</code>", |get|).
-    1.  Let |getOwnPropertyDescriptor| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-getOwnPropertyDescriptor]], « », |realm|).
+    1.  Let |getOwnPropertyDescriptor| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-getOwnPropertyDescriptor]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>getOwnPropertyDescriptor</code>", |getOwnPropertyDescriptor|).
-    1.  Let |has| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-has]], « », |realm|).
+    1.  Let |has| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-has]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>has</code>", |has|).
-    1.  Let |ownKeys| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-ownKeys]], « », |realm|).
+    1.  Let |ownKeys| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-ownKeys]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>ownKeys</code>", |ownKeys|).
-    1.  Let |preventExtensions| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-preventExtensions]], « », |realm|).
+    1.  Let |preventExtensions| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-preventExtensions]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>preventExtensions</code>", |preventExtensions|).
-    1.  Let |set| be [=!=] [$CreateBuiltinFunction$](the steps from [[#es-observable-array-set]], « », |realm|).
+    1.  Let |set| be [$CreateBuiltinFunction$](the steps from [[#es-observable-array-set]], « », |realm|).
     1.  Perform [=!=] [$CreateDataProperty$](|handler|, "<code>set</code>", |set|).
     1.  Return [=!=] [$ProxyCreate$](|innerArray|, |handler|).
 </div>
@@ -13922,7 +13922,7 @@ those of normal <code>Array</code> instances:
     1.  Let |handler| be the <emu-val>this</emu-val> value.
     1.  Let |descriptor| be [=!=] [$ToPropertyDescriptor$](|descriptorObj|).
     1.  If |P| is "length", then:
-        1.  If [=!=] [$IsAccessorDescriptor$](|descriptor|) is <emu-val>true</emu-val>, then return
+        1.  If [$IsAccessorDescriptor$](|descriptor|) is <emu-val>true</emu-val>, then return
             <emu-val>false</emu-val>.
         1.  If |descriptor|.\[[Configurable]] is present and has the value <emu-val>true</emu-val>,
             then return <emu-val>false</emu-val>.
@@ -13935,7 +13935,7 @@ those of normal <code>Array</code> instances:
             |descriptor|.\[[Value]].
         1.  Return <emu-val>true</emu-val>.
     1. If |P| [=is an array index=], then:
-        1.  If [=!=] [$IsAccessorDescriptor$](|descriptor|) is <emu-val>true</emu-val>, then return
+        1.  If [$IsAccessorDescriptor$](|descriptor|) is <emu-val>true</emu-val>, then return
             <emu-val>false</emu-val>.
         1.  If |descriptor|.\[[Configurable]] is present and has the value <emu-val>false</emu-val>,
             then return <emu-val>false</emu-val>.
@@ -14007,10 +14007,10 @@ those of normal <code>Array</code> instances:
         1.  Let |esValue| be the result of [=converted to an ECMAScript value|converting=]
             |handler|.\[[BackingList]][|index|] to an ECMAScript value.
         1.  Assert: the above step never throws an exception.
-        1.  Return [=!=] [$FromPropertyDescriptor$](PropertyDescriptor{\[[Configurable]]:
+        1.  Return [$FromPropertyDescriptor$](PropertyDescriptor{\[[Configurable]]:
             <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Writable]]:
             <emu-val>true</emu-val>, \[[Value]]: |esValue| }).
-    1.  Return [=!=] [$FromPropertyDescriptor$]([=?=] |O|.\[[GetOwnProperty]](|P|)).
+    1.  Return [$FromPropertyDescriptor$]([=?=] |O|.\[[GetOwnProperty]](|P|)).
 </div>
 
 <h4 id="es-observable-array-has"><code>has</code></h4>
@@ -14043,7 +14043,7 @@ those of normal <code>Array</code> instances:
         1.  [=list/Append=] [=!=] [$ToString$](|i|) to |keys|.
         1.  Set |i| to |i| + 1.
     1.  [=list/Extend=] |keys| with [=!=] |O|.\[[OwnPropertyKeys]]().
-    1.  Return [=!=] [$CreateArrayFromList$](|keys|).
+    1.  Return [$CreateArrayFromList$](|keys|).
 </div>
 
 <h4 id="es-observable-array-preventExtensions"><code>preventExtensions</code></h4>
@@ -14170,12 +14170,12 @@ the special value “missing”, which represents a missing optional argument.
     1.  [=Prepare to run script=] with |relevant settings|.
     1.  [=Prepare to run a callback=] with |stored settings|.
     1.  Let |X| be |O|.
-    1.  If [=!=] <a abstract-op>IsCallable</a>(|O|) is false, then:
+    1.  If <a abstract-op>IsCallable</a>(|O|) is false, then:
         1.  Let |getResult| be <a abstract-op>Get</a>(|O|, |opName|).
         1.  If |getResult| is an [=abrupt completion=], set |completion|
             to |getResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |X| to |getResult|.\[[Value]].
-        1.  If [=!=] <a abstract-op>IsCallable</a>(|X|) is <emu-val>false</emu-val>,
+        1.  If <a abstract-op>IsCallable</a>(|X|) is <emu-val>false</emu-val>,
             then set |completion| to a new <a abstract-op>Completion</a>{\[[Type]]: throw, \[[Value]]: a
             newly created {{ECMAScript/TypeError}} object, \[[Target]]: empty}, and jump
             to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
@@ -14231,9 +14231,9 @@ when applied to a [=legacy callback interface object=].
 
     1.  Let |steps| be the following steps:
         1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
-    1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
-    1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
-    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, 0).
+    1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
+    1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |id|).
+    1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, 0).
     1.  [=Define the constants=] of |interface| on |F| given |realm|.
     1.  Return |F|.
 </div>
@@ -14258,7 +14258,7 @@ described in the previous section).
     1.  Let |completion| be an uninitialized variable.
     1.  If |thisArg| was not given, let |thisArg| be <emu-val>undefined</emu-val>.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
-    1.  If [=!=] <a abstract-op>IsCallable</a>(|F|) is <emu-val>false</emu-val>:
+    1.  If <a abstract-op>IsCallable</a>(|F|) is <emu-val>false</emu-val>:
         1.  Note: This is only possible when the [=callback function=] came from an attribute
             marked with [{{LegacyTreatNonObjectAsNull}}].
         1.  Return the result of [=converted to an IDL value|converting=]
@@ -14303,7 +14303,7 @@ a return type that is a [=promise type=].
 
     1.  Let |completion| be an uninitialized variable.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
-    1.  If [=!=] <a abstract-op>IsConstructor</a>(|F|) is <emu-val>false</emu-val>, throw a
+    1.  If <a abstract-op>IsConstructor</a>(|F|) is <emu-val>false</emu-val>, throw a
         {{ECMAScript/TypeError}} exception.
     1.  Let |realm| be |F|'s [=associated Realm=].
     1.  Let |relevant settings| be |realm|'s [=Realm/settings object=].
@@ -14345,7 +14345,7 @@ The characteristics of a namespace object are described in [[#namespace-object]]
     The namespace object for a given [=namespace=] |namespace| and [=Realm=] |realm|
     is <dfn lt="create a namespace object">created</dfn> as follows:
 
-    1.  Let |namespaceObject| be [=!=] [$OrdinaryObjectCreate$](|realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]]).
+    1.  Let |namespaceObject| be [$OrdinaryObjectCreate$](|realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]]).
     1.  [=Define the regular attributes=] of |namespace| on |namespaceObject| given |realm|.
     1.  [=Define the regular operations=] of |namespace| on |namespaceObject| given |realm|.
     1.  [=Define the constants=] of |namespace| on |namespaceObject| given |realm|.
@@ -14354,7 +14354,7 @@ The characteristics of a namespace object are described in [[#namespace-object]]
         1.  Let |id| be |interface|'s [=identifier=].
         1.  Let |interfaceObject| be the result of [=create an interface object|creating an
             interface object=] for |interface| with |id| in |realm|.
-        1.  Perform [=!=] [$CreateMethodProperty$](|namespaceObject|, |id|, |interfaceObject|).
+        1.  Perform [$CreateMethodProperty$](|namespaceObject|, |id|, |interfaceObject|).
     1.  Return |namespaceObject|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -14175,7 +14175,7 @@ the special value “missing”, which represents a missing optional argument.
     1.  [=Prepare to run a callback=] with |stored settings|.
     1.  Let |X| be |O|.
     1.  If <a abstract-op>IsCallable</a>(|O|) is false, then:
-        1.  Let |getResult| be <a abstract-op>Completion(<a abstract-op>Get</a>(|O|, |opName|)).
+        1.  Let |getResult| be <a abstract-op>Completion</a>(<a abstract-op>Get</a>(|O|, |opName|)).
         1.  If |getResult| is an [=abrupt completion=], set |completion|
             to |getResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |X| to |getResult|.\[[Value]].
@@ -14188,7 +14188,7 @@ the special value “missing”, which represents a missing optional argument.
         arguments list. If this throws an exception, set |completion| to the completion value
         representing the thrown exception and jump to the step labeled
         <a href="#call-user-object-operation-return"><i>return</i></a>.
-    1.  Let |callResult| be <a abstract-op>Completion(<a abstract-op>Call</a>(|X|, |thisArg|, |esArgs|)).
+    1.  Let |callResult| be <a abstract-op>Completion</a>(<a abstract-op>Call</a>(|X|, |thisArg|, |esArgs|)).
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
@@ -14276,7 +14276,7 @@ described in the previous section).
         arguments list. If this throws an exception, set |completion| to the completion value
         representing the thrown exception and jump to the step labeled
         <a href="#invoke-return"><i>return</i></a>.
-    1.  Let |callResult| be <a abstract-op>Completion(<a abstract-op>Call</a>(|F|, |thisArg|, |esArgs|)).
+    1.  Let |callResult| be <a abstract-op>Completion</a>(<a abstract-op>Call</a>(|F|, |thisArg|, |esArgs|)).
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
@@ -14318,7 +14318,7 @@ a return type that is a [=promise type=].
         arguments list. If this throws an exception, set |completion| to the completion value
         representing the thrown exception and jump to the step labeled
         <a href="#construct-return"><i>return</i></a>.
-    1.  Let |callResult| be <a abstract-op>Completion(<a abstract-op>Construct</a>(|F|, |esArgs|)).
+    1.  Let |callResult| be <a abstract-op>Completion</a>(<a abstract-op>Construct</a>(|F|, |esArgs|)).
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#construct-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]

--- a/index.bs
+++ b/index.bs
@@ -8072,8 +8072,8 @@ ECMAScript Array values.
         1.  Let |V| be the value in |S| at index |i|.
         1.  Let |E| be the result of [=converted to an ECMAScript value|converting=]
             |V| to an ECMAScript value.
-        1.  Let |P| be the result of calling [=?=] <a abstract-op>ToString</a>(|i|).
-        1.  Call [=?=] <a abstract-op>CreateDataProperty</a>(|A|, |P|, |E|).
+        1.  Let |P| be the result of calling [=!=] <a abstract-op>ToString</a>(|i|).
+        1.  Call [=!=] <a abstract-op>CreateDataProperty</a>(|A|, |P|, |E|).
         1.  Set |i| to |i| + 1.
     1.  Return |A|.
 </div>
@@ -9095,7 +9095,7 @@ Array object references.
     1.  Let |array| be the result of
         [=converted to an ECMAScript value|converting=]
         the sequence of values of type |T| to an ECMAScript value.
-    1.  Perform [=?=] <a abstract-op>SetIntegrityLevel</a>(|array|, "<code>frozen</code>").
+    1.  Perform [=!=] <a abstract-op>SetIntegrityLevel</a>(|array|, "<code>frozen</code>").
     1.  Return |array|.
 </div>
 
@@ -13623,7 +13623,7 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
                 1.  Return <emu-val>true</emu-val>.
     1.  If |O| does not implement an [=interface=] with the [{{Global}}] [=extended attribute=],
         then set |Desc|.\[[Configurable]] to <emu-val>true</emu-val>.
-    1.  Return [=?=] <a abstract-op>OrdinaryDefineOwnProperty</a>(|O|, |P|, |Desc|).
+    1.  Return [=!=] <a abstract-op>OrdinaryDefineOwnProperty</a>(|O|, |P|, |Desc|).
 </div>
 
 


### PR DESCRIPTION
As part of the https://github.com/tc39/ecma262/pull/2547 ecma262 has reformed how it deals with Completion Records. See https://github.com/tc39/ecma262/issues/253#issuecomment-1050160672 for a brief description of when to use `?` vs `!` vs nothing at all.

This PR was generated in part by [this script](https://gist.github.com/syg/47652ec9ee938707b93807a5b3fed768) being passed `index.bs` and a locally generated copy of ecma262's `biblio.json`.

It is probably easier to review this PR commit-by-commit.

This is the counterpart to https://github.com/whatwg/html/pull/7661.

/cc other ecma262 editors @bakkot and @michaelficarra


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1111.html" title="Last updated on Mar 1, 2022, 11:56 PM UTC (ae45b77)">Preview</a> | <a href="https://whatpr.org/webidl/1111/e5afaf7...ae45b77.html" title="Last updated on Mar 1, 2022, 11:56 PM UTC (ae45b77)">Diff</a>