### PR TITLE
Export observable array attribute/backing list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6729,7 +6729,7 @@ Note that when ECMAScript code sets an existing index to a new value, this will 
 then the [=observable array attribute/set an indexed value=] algorithm with the new value.
 
 Every [=regular attribute=] whose type is an [=observable array type=] has a
-<dfn for="observable array attribute">backing list</dfn>, which is a [=list=], initially empty.
+<dfn export for="observable array attribute">backing list</dfn>, which is a [=list=], initially empty.
 Specification authors can modify the contents of the backing list, which will automatically be
 reflected in the contents of the observable array as observed by ECMAScript code. Similarly, any
 modifications by ECMAScript code to the contents of the observable array will be reflected back into


### PR DESCRIPTION
Exporting the "backing list" definition for observable arrays, since most (all?) definitions of the observable array algos will need to reference it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1124.html" title="Last updated on Apr 19, 2022, 8:32 PM UTC (5bf62d2)">Preview</a> | <a href="https://whatpr.org/webidl/1124/2c45ffc...5bf62d2.html" title="Last updated on Apr 19, 2022, 8:32 PM UTC (5bf62d2)">Diff</a>