### PR TITLE
Export getter/setter steps, and note the tools you have access to when defining them.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2351,10 +2351,12 @@ The following extended attributes are applicable to operations:
 [{{NewObject}}], and
 [{{SecureContext}}].
 
-The <dfn>method steps</dfn> of an operation |operation| should be introduced using text of the form
+The <dfn export>method steps</dfn> of an operation |operation| should be introduced using text of the form
 “The <code>|operation|(<var ignore>arg1</var>, <var ignore>arg2</var>, ...)</code> method
 steps are:” followed by a list, or “The <code>|operation|(<var ignore>arg1</var>,
 <var ignore>arg2</var>, ...)</code> method steps are to” followed by an inline description.
+
+Note: When defining [=method steps=], you implicitly have access to [=this=].
 
 <pre class="grammar" id="prod-DefaultValue">
     DefaultValue :
@@ -2559,7 +2561,7 @@ Multiple [=constructor operations=] may appear on a given [=interface=].
 For each [=constructor operation=] on the [=interface=], there will be a way to attempt to
 construct an instance by passing the specified arguments.
 
-The <dfn>constructor steps</dfn> of a [=constructor operation=] that is a member of an interface
+The <dfn export>constructor steps</dfn> of a [=constructor operation=] that is a member of an interface
 named |interface| should be introduced using text of the form “The
 <code>new |interface|(<var ignore>arg1</var>, <var ignore>arg2</var>, ...)</code> constructor steps
 are:” followed by a list, or “The

--- a/index.bs
+++ b/index.bs
@@ -1793,13 +1793,17 @@ If an attribute has no <emu-t>static</emu-t> keyword, then it declares a
 it declares a [=static attribute=]. Note that in addition to being [=interface members=],
 [=read only=] [=regular attributes=] can be [=namespace members=] as well.
 
-The <dfn>getter steps</dfn> of an attribute |attr| should be introduced using text of the form “The
+The <dfn export>getter steps</dfn> of an attribute |attr| should be introduced using text of the form “The
 <code>|attr|</code> getter steps are:” followed by a list, or “The <code>|attr|</code> getter steps
 are to” followed by an inline description.
 
-The <dfn>setter steps</dfn> of an attribute |attr| should be introduced using text of the form “The
+The <dfn export>setter steps</dfn> of an attribute |attr| should be introduced using text of the form “The
 <code>|attr|</code> setter steps are:” followed by a list, or “The <code>|attr|</code> setter steps
 are to” followed by an inline description.
+
+Note: When defining [=getter steps=], you implicitly have access to [=this=].
+When defining [=setter steps=], you implicitly have access to [=this=] and
+[=the given value=].
 
 The [=identifier=] of an
 [=attribute=]


### PR DESCRIPTION
I was surprised and glad to see that getters/setters have defined terminology to work from now, but unfortunately the dfns weren't exported.

I also initially wrote my algos explicitly taking in a |this| (and a |val| for the setters) and only coincidentally remembered that [=this=] exists, which is also when I learned that [=the given value=] exists. To help myself and others in the future, I've dropped a Note here to remind of their existence, since the terms are defined elsewhere in the spec and not linked anywhere nearby.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1130.html" title="Last updated on Apr 26, 2022, 5:50 PM UTC (4643902)">Preview</a> | <a href="https://whatpr.org/webidl/1130/c2b9c12...4643902.html" title="Last updated on Apr 26, 2022, 5:50 PM UTC (4643902)">Diff</a>