### PR TITLE
Remove the concept of 'type name'. Closes #835

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5650,11 +5650,6 @@ all [=interface types=], and
 all [=callback interface types=]
 are known as <dfn id="dfn-object-type" export>object types</dfn>.
 
-Every type has a <dfn id="dfn-type-name" export>type name</dfn>, which
-is a string, not necessarily unique, that identifies the type.
-Each sub-section below defines what the type name is for each
-type.
-
 <p id="type-conversion-exceptions">
     When conversions are made from language binding specific types to
     IDL types in order to invoke an [=operation=]
@@ -5789,7 +5784,6 @@ type.
 
 The {{any}} type is the union of all other possible
 non-[=union type|union=] types.
-Its [=type name=] is "<code>Any</code>".
 
 The {{any}} type is like
 a discriminated union type, in that each of its values has a
@@ -5812,8 +5806,6 @@ The {{undefined}} type has a unique value.
 {{undefined}} constant values in IDL
 are represented with the <emu-t>undefined</emu-t> token.
 
-The [=type name=] of the {{undefined}} type is "<code>Undefined</code>".
-
 {{undefined}} must not be used as the type of an argument in any circumstance
 (in an [=operation=], [=callback function=], [=constructor operation=], etc),
 or as the type of a [=dictionary member=],
@@ -5824,7 +5816,6 @@ or a non-[=dictionary member/required=] [=dictionary member=].
 Note: This value was previously spelled <code>void</code>,
 and more limited in how it was allowed to be used.
 
-
 <h4 oldids="dom-boolean" id="idl-boolean" interface>boolean</h4>
 
 The {{boolean}} type has two values:
@@ -5833,10 +5824,6 @@ The {{boolean}} type has two values:
 {{boolean}} constant values in IDL are
 represented with the <emu-t>true</emu-t> and
 <emu-t>false</emu-t> tokens.
-
-The [=type name=] of the
-{{boolean}} type is "<code>Boolean</code>".
-
 
 <h4 oldids="dom-byte" id="idl-byte" interface>byte</h4>
 
@@ -5847,10 +5834,6 @@ type that has values in the range [−128, 127].
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
-The [=type name=] of the
-{{byte}} type is "<code>Byte</code>".
-
-
 <h4 oldids="dom-octet" id="idl-octet" interface>octet</h4>
 
 The {{octet}} type is an unsigned integer
@@ -5859,10 +5842,6 @@ type that has values in the range [0, 255].
 {{octet}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
-
-The [=type name=] of the
-{{octet}} type is "<code>Octet</code>".
-
 
 <h4 oldids="dom-short" id="idl-short" interface>short</h4>
 
@@ -5873,10 +5852,6 @@ type that has values in the range [−32768, 32767].
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
-The [=type name=] of the
-{{short}} type is "<code>Short</code>".
-
-
 <h4 oldids="dom-unsignedshort" id="idl-unsigned-short" interface>unsigned short</h4>
 
 The {{unsigned short}} type is an unsigned integer
@@ -5885,10 +5860,6 @@ type that has values in the range [0, 65535].
 {{unsigned short}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
-
-The [=type name=] of the
-{{unsigned short}} type is "<code>UnsignedShort</code>".
-
 
 <h4 oldids="dom-long" id="idl-long" interface>long</h4>
 
@@ -5899,10 +5870,6 @@ type that has values in the range [−2147483648, 2147483647].
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
-The [=type name=] of the
-{{long}} type is "<code>Long</code>".
-
-
 <h4 oldids="dom-unsignedlong" id="idl-unsigned-long" interface>unsigned long</h4>
 
 The {{unsigned long}} type is an unsigned integer
@@ -5911,10 +5878,6 @@ type that has values in the range [0, 4294967295].
 {{unsigned long}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
-
-The [=type name=] of the
-{{unsigned long}} type is "<code>UnsignedLong</code>".
-
 
 <h4 oldids="dom-longlong" id="idl-long-long" interface>long long</h4>
 
@@ -5925,10 +5888,6 @@ type that has values in the range [−9223372036854775808, 9223372036854775807].
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
-The [=type name=] of the
-{{long long}} type is "<code>LongLong</code>".
-
-
 <h4 oldids="dom-unsignedlonglong" id="idl-unsigned-long-long" interface>unsigned long long</h4>
 
 The {{unsigned long long}} type is an unsigned integer
@@ -5937,10 +5896,6 @@ type that has values in the range [0, 18446744073709551615].
 {{unsigned long long}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
-
-The [=type name=] of the
-{{unsigned long long}} type is "<code>UnsignedLongLong</code>".
-
 
 <h4 oldids="dom-float" id="idl-float" interface>float</h4>
 
@@ -5952,9 +5907,6 @@ IEEE 754 floating point numbers. [[!IEEE-754]]
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
-The [=type name=] of the
-{{float}} type is "<code>Float</code>".
-
 <p class="warning">
     Unless there are specific reasons to use a 32 bit floating point type,
     specifications should use
@@ -5962,7 +5914,6 @@ The [=type name=] of the
     since the set of values that a {{double}} can
     represent more closely matches an ECMAScript Number.
 </p>
-
 
 <h4 oldids="dom-unrestrictedfloat" id="idl-unrestricted-float" interface>unrestricted float</h4>
 
@@ -5974,10 +5925,6 @@ IEEE 754 floating point numbers, finite, non-finite, and special "not a number" 
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
-The [=type name=] of the
-{{unrestricted float}} type is "<code>UnrestrictedFloat</code>".
-
-
 <h4 oldids="dom-double" id="idl-double" interface>double</h4>
 
 The {{double}} type is a floating point numeric
@@ -5987,10 +5934,6 @@ IEEE 754 floating point numbers. [[!IEEE-754]]
 {{double}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
-
-The [=type name=] of the
-{{double}} type is "<code>Double</code>".
-
 
 <h4 oldids="dom-unrestricteddouble" id="idl-unrestricted-double" interface>unrestricted double</h4>
 
@@ -6002,19 +5945,12 @@ IEEE 754 floating point numbers, finite, non-finite, and special "not a number" 
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
-The [=type name=] of the
-{{unrestricted double}} type is "<code>UnrestrictedDouble</code>".
-
-
 <h4 id="idl-bigint" interface>bigint</h4>
 
 The {{bigint}} type is an arbitrary integer type, unrestricted in range.
 
 {{bigint}} constant values in IDL are represented with
 <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> tokens.
-
-The [=type name=] of the {{bigint}} type is “<code>BigInt</code>”.
-
 
 <h4 oldids="dom-DOMString" id="idl-DOMString" interface>DOMString</h4>
 
@@ -6042,10 +5978,6 @@ and [=optional argument|operation optional argument=] [=optional argument/defaul
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
-The [=type name=] of the
-{{DOMString}} type is "<code>String</code>".
-
-
 <h4 oldids="dom-ByteString" id="idl-ByteString" interface>ByteString</h4>
 
 The {{ByteString}} type
@@ -6058,9 +5990,6 @@ value in IDL, although {{ByteString}} [=dictionary member=] [=dictionary member/
 and [=optional argument|operation optional argument=] [=optional argument/default values=]
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
-
-The [=type name=] of the
-{{ByteString}} type is "<code>ByteString</code>".
 
 <p class="warning">
     Specifications should only use
@@ -6090,9 +6019,6 @@ and [=optional argument|operation optional argument=] [=optional argument/defaul
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
-The [=type name=] of the
-{{USVString}} type is "<code>USVString</code>".
-
 <p class="warning">
     Specifications should only use
     {{USVString}} for APIs that perform
@@ -6116,18 +6042,12 @@ To denote a type that includes all possible object references plus the
 <emu-val>null</emu-val> value, use the [=nullable type=]
 <code class="idl">object?</code>.
 
-The [=type name=] of the
-{{object}} type is "<code>Object</code>".
-
 <h4 id="idl-symbol" interface>symbol</h4>
 
 The {{symbol}} type corresponds to the set of all possible symbol values. Symbol values are opaque,
 non-{{object}} values which nevertheless have identity (i.e., are only equal to themselves).
 
 There is no way to represent a constant {{symbol}} value in IDL.
-
-The [=type name=] of the {{symbol}} type is "<code>Symbol</code>".
-
 
 <h4 id="idl-interface" dfn>Interface types</h4>
 
@@ -6145,10 +6065,6 @@ a particular interface type in IDL.
 To denote a type that includes all possible references to objects implementing
 the given interface plus the <emu-val>null</emu-val> value,
 use a [=nullable type=].
-
-The [=type name=] of an interface type
-is the [=identifier=] of the interface.
-
 
 <h4 id="idl-callback-interface" dfn>Callback interface types</h4>
 
@@ -6171,10 +6087,6 @@ There is no way to represent a constant object reference value for a particular
 To denote a type that includes all possible references to objects plus the <emu-val>null</emu-val>
 value, use a [=nullable type=].
 
-The [=type name=] of a [=callback interface type=] is the [=identifier=] of the
-[=callback interface=].
-
-
 <h4 id="idl-dictionary" dfn>Dictionary types</h4>
 
 An [=identifier=] that
@@ -6186,10 +6098,6 @@ The literal syntax for [=ordered maps=] may also be used to represent dictionari
 implicitly understood from context that the map is being treated as an instance of a specific
 dictionary type. However, there is no way to represent a constant dictionary value inside IDL
 fragments.
-
-The [=type name=] of a dictionary type
-is the [=identifier=] of the dictionary.
-
 
 <h4 id="idl-enumeration" dfn export>Enumeration types</h4>
 
@@ -6205,10 +6113,6 @@ value in IDL, although enumeration-typed [=dictionary member=] [=dictionary memb
 and [=optional argument|operation optional argument=] [=optional argument/default values=]
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
-
-The [=type name=] of an enumeration type
-is the [=identifier=] of the enumeration.
-
 
 <h4 id="idl-callback-function" dfn>Callback function types</h4>
 
@@ -6229,10 +6133,6 @@ callback function type value.  See [[#es-callback-function]].
 
 There is no way to represent a constant [=callback function=]
 value in IDL.
-
-The [=type name=] of a callback function type
-is the [=identifier=] of the callback function.
-
 
 <h4 id="idl-nullable-type">Nullable types — |T|?</h4>
 
@@ -6257,10 +6157,6 @@ they cannot when used as the type of an operation argument or a dictionary membe
 Nullable type constant values in IDL are represented in the same way that
 constant values of their [=nullable types/inner type=]
 would be represented, or with the <emu-t>null</emu-t> token.
-
-The [=type name=] of a nullable type
-is the concatenation of the type name of the [=nullable types/inner type=] |T| and
-the string "<code>OrNull</code>".
 
 <div class="example" id="example-93b2f0cf">
 
@@ -6320,10 +6216,6 @@ to them passed around.  Instead of a writable [=attribute=] of a sequence
 type, it is suggested that a pair of [=operations=] to get and set the
 sequence is used.
 
-The [=type name=] of a sequence type
-is the concatenation of the type name for |T| and
-the string "<code>Sequence</code>".
-
 Any [=list=] can be implicitly treated as a <code>sequence&lt;|T|&gt;</code>, as long as it contains
 only [=list/items=] that are of type |T|.
 
@@ -6348,9 +6240,6 @@ to the platform object.
 Records must not be used as the type of an [=attribute=] or
 [=constant=].
 
-The [=type name=] of a record type is the concatenation of the type
-name for |K|, the type name for |V| and the string "<code>Record</code>".
-
 Any [=ordered map=] can be implicitly treated as a <code>record&lt;|K|, |V|&gt;</code>, as long as
 it contains only [=map/entries=] whose [=map/keys=] are all of of type |K| and whose [=map/values=]
 are all of type |V|.
@@ -6368,11 +6257,6 @@ of the ECMAScript specification for details on the semantics of promise objects.
 Promise types are non-nullable, but |T| may be nullable.
 
 There is no way to represent a promise value in IDL.
-
-The [=type name=] of a promise type
-is the concatenation of the type name for |T| and
-the string "<code>Promise</code>".
-
 
 <h4 id="idl-union">Union types</h4>
 
@@ -6497,10 +6381,6 @@ in IDL are represented in the same way that constant values of their
 [=member types=] would be
 represented.
 
-The [=type name=] of a union
-type is formed by taking the type names of each member type, in order,
-and joining them with the string "<code>Or</code>".
-
 <div data-fill-with="grammar-UnionType"></div>
 
 <div data-fill-with="grammar-UnionMemberType"></div>
@@ -6618,14 +6498,6 @@ The following extended attributes are <dfn for="extended attributes">applicable 
 For any type, the [=extended attributes associated with=] it must only contain
 [=extended attributes=] that are [=applicable to types=].
 
-The [=type name=] of a type associated with [=extended attributes=] is the concatenation of the
-type name of the original type with the set of strings corresponding to the [=identifiers=] of each
-[=extended attribute associated with=] the type, sorted in lexicographic order.
-
-<div class="example" id="example-4533b815">
-    The [=type name=] for a type of the form <code>[B, A] long?</code> is "LongOrNullAB".
-</div>
-
 <h4 id="idl-buffer-source-types">Buffer source types</h4>
 
 There are a number of types that correspond to sets of all possible non-null
@@ -6656,9 +6528,6 @@ data.  The table below lists these types and the kind of buffer or view they rep
 Note: These types all correspond to classes defined in ECMAScript.
 
 There is no way to represent a constant value of any of these types in IDL.
-
-The [=type name=] of all
-of these types is the name of the type itself.
 
 At the specification prose level, IDL [=buffer source types=] are simply references to objects. To
 inspect or manipulate the bytes inside the buffer, specification prose needs to use the algorithms
@@ -6693,10 +6562,6 @@ are references, they are unlike [=sequence types=],
 which are lists of values that are passed by value.
 
 There is no way to represent a constant frozen array value in IDL.
-
-The [=type name=] of a frozen array
-type is the concatenation of the type name for |T| and the string
-"<code>Array</code>".
 
 <h4 id="idl-observable-array" interface lt="ObservableArray|ObservableArray&lt;T&gt;">Observable array types — ObservableArray&lt;|T|&gt;</h4>
 
@@ -6737,9 +6602,6 @@ the backing list, after passing through the [=observable array attribute/set an 
 [=observable array attribute/delete an indexed value=] algorithms.
 
 There is no way to represent a constant observable array value in IDL.
-
-The [=type name=] of an observable array type is the concatenation of the type name for |T| and the
-string "<code>ObservableArray</code>".
 
 <div class="example" id="example-observable-array" oldids="example-af5d265e">
     The following [=IDL fragment=] defines an [=interface=] with an observable array attribute:
@@ -8886,11 +8748,9 @@ are represented by objects of the corresponding ECMAScript class, with the follo
     by running the following algorithm:
 
     1.  Let |T| be the IDL type |V| is being converted to.
-    1.  Let |typedArrayName| be the [=type name|name=] of |T|'s [=annotated types/inner type=] if
-        |T| is an [=annotated type=], or the [=type name|name=] of |T| otherwise.
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have a \[[TypedArrayName]] [=internal slot=]
-        with a value equal to |typedArrayName|,
+        with a value equal to |T|'s name,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]


### PR DESCRIPTION
Per #835, the "type name" concept is no longer actively used by the specification. It was originally introduced in <https://github.com/whatwg/webidl/commit/8e66595d495b40d05c9926fbd01b0fa0be5ecb6a>, where it was necessary to create a author-observable name for the Array subclasses created by the `T[]` syntax, but that syntax is dead. We've been keeping carrying the concept forward out of inertia since then.

The only remaining usage of it (besides all the places where types define their type name) was in the algo for converting ES values to the IDL buffer source types; it's used solely to verify that the ES value is of the same-named type as the IDL type it's being converted to. Since the "type name" of the buffer source types was just defined as "the name of the type itself", I inlined that language into the algo instead. (This technically makes it more correct, too - the algo implies it can be called on annotated buffer source types, but the intro text only mentions the buffer source types themselves and says nothing about annotations. Now no mention is made of annotated types at all, which matches all the other similar algos.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1132.html" title="Last updated on Apr 28, 2022, 10:18 PM UTC (c742908)">Preview</a> | <a href="https://whatpr.org/webidl/1132/c2b9c12...c742908.html" title="Last updated on Apr 28, 2022, 10:18 PM UTC (c742908)">Diff</a>