### PR TITLE
Editorial: fix uses of `?` with `IfAbruptRejectPromise`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12568,7 +12568,7 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
     1.  Let |thisValidationPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
 
     1.  Let |thisValue| be the <emu-val>this</emu-val> value.
-    1.  Let |object| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
+    1.  Let |object| be <a abstract-op>Completion</a>(<a abstract-op>ToObject</a>(|thisValue|)).
 
     1.  [$IfAbruptRejectPromise$](|object|, |thisValidationPromiseCapability|).
 
@@ -12658,7 +12658,7 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
     1.  Let |returnPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
 
     1.  Let |thisValue| be the <emu-val>this</emu-val> value.
-    1.  Let |object| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
+    1.  Let |object| be <a abstract-op>Completion</a>(<a abstract-op>ToObject</a>(|thisValue|)).
 
     1.  [$IfAbruptRejectPromise$](|object|, |returnPromiseCapability|).
 


### PR DESCRIPTION
This was a typo introduced in https://github.com/whatwg/webidl/pull/1111; cc @syg. Sorry I didn't catch it at the time. Context follows but feel free to skip it.

---

[`?`](https://tc39.es/ecma262/multipage/notational-conventions.html#sec-returnifabrupt-shorthands) is a macro in the JS spec which expands to [`ReturnIfAbrupt`](https://tc39.es/ecma262/multipage/notational-conventions.html#sec-returnifabrupt) and which is used when possible errors need to get propagated immediately. In the case of non-errors it unwraps the completion record for use in later steps.

[`IfAbruptRejectPromise`](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-ifabruptrejectpromise) is a macro in the JS spec which is used when possible errors need to get wrapped up into rejected promises. As above, in the case of non-errors it unwraps the completion record for use in later steps.

They reflect two different kinds of error handling, basically corresponding to errors which occur in sync and async functions respectively. They can't be combined for the same call, since whichever runs first will handle the error. But they were both being done in [this algorithm](https://webidl.spec.whatwg.org/#es-asynchronous-iterator-prototype-object). The behavior prior to #1111 was consistent with this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1165.html" title="Last updated on Jul 7, 2022, 5:13 PM UTC (7290883)">Preview</a> | <a href="https://whatpr.org/webidl/1165/69c0e4d...7290883.html" title="Last updated on Jul 7, 2022, 5:13 PM UTC (7290883)">Diff</a>