### PR TITLE
Fix incorrect wording in `2.9. Enumerations`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5381,7 +5381,7 @@ must not include duplicates.
     similar APIs are consistent.
 </p>
 
-The behavior when a string value that is not one a valid enumeration value
+The behavior when a string value that is not a valid enumeration value
 is used when assigning to an [=attribute=],
 or passed as an [=operation=] argument,
 whose type is the enumeration, is language binding specific.


### PR DESCRIPTION
fixes #972


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1173.html" title="Last updated on Jul 23, 2022, 12:23 PM UTC (ea276b1)">Preview</a> | <a href="https://whatpr.org/webidl/1173/7c6e257...ea276b1.html" title="Last updated on Jul 23, 2022, 12:23 PM UTC (ea276b1)">Diff</a>