### PR TITLE
Ensure [Expose=*] works when the global object is not defined using IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9422,6 +9422,23 @@ The <dfn>own exposure set</dfn> is either a [=/set=] of identifiers or the speci
 </p>
 
 <div algorithm>
+
+The <dfn>exposure set intersection</dfn> of a construct |C| and interface-or-null |H| is defined as
+follows:
+
+1.  Assert: |C| is an [=interface member=], [=interface mixin member=], [=namespace member=],
+    [=partial interface=], [=partial interface mixin=], [=partial namespace=], or
+    [=interface mixin=].
+1.  Assert: |H| is an [=interface=] or null.
+1.  If |H| is null, return |C|'s [=own exposure set=].
+1.  If |C|'s [=own exposure set=] is <code>*</code>, return |H|'s [=exposure set=].
+1.  If |H|'s [=exposure set=] is <code>*</code>, return |C|'s [=own exposure set=].
+1.  Return the [=set/intersection=] of |C|'s [=own exposure set=] and |H|'s
+    [=exposure set=].
+
+</div>
+
+<div algorithm>
     To get the <dfn id="dfn-exposure-set" export>exposure set</dfn> of a construct |C|,
     run the following steps:
 
@@ -9429,33 +9446,22 @@ The <dfn>own exposure set</dfn> is either a [=/set=] of identifiers or the speci
         [=interface member=], [=interface mixin member=], or [=namespace member=].
     1.  Let |H| be |C|'s [=host interface=] if |C| is an [=interface mixin member=], or null otherwise.
     1.  If |C| is an [=interface member=], [=interface mixin member=], or [=namespace member=], then:
-        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|, then:
-            1.  If |H| is null, return |C|'s [=own exposure set=].
-            1.  If |C|'s [=own exposure set=] is <code>*</code>, return |H|'s [=exposure set=].
-            1.  If |H|'s [=exposure set=] is <code>*</code>, return |C|'s [=own exposure set=].
-            1.  Return the [=set/intersection=] of |C|'s [=own exposure set=] and |H|'s
-                [=exposure set=].
+        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|,
+            return the [=exposure set intersection=] of |C| and |H|.
         1.  Set |C| to the
             [=interface=], [=partial interface=],
             [=interface mixin=], [=partial interface mixin=],
             [=namespace=], or [=partial namespace=]
             |C| is declared on.
     1.  If |C| is a [=partial interface=], [=partial interface mixin=], or [=partial namespace=], then:
-        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|, then:
-            1.  If |H| is null, return |C|'s [=own exposure set=].
-            1.  If |C|'s [=own exposure set=] is <code>*</code>, return |H|'s [=exposure set=].
-            1.  If |H|'s [=exposure set=] is <code>*</code>, return |C|'s [=own exposure set=].
-            1.  Return the [=set/intersection=] of |C|'s [=own exposure set=] and |H|'s
-                [=exposure set=].
+        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|,
+            return the [=exposure set intersection=] of |C| and |H|.
         1.  Set |C| to the original [=interface=], [=interface mixin=], or [=namespace=] definition
             of |C|.
     1.  If |C| is an [=interface mixin=], then:
         1.  Assert: |H| is not null.
-        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|, then:
-            1.  If |C|'s [=own exposure set=] is <code>*</code>, return |H|'s [=exposure set=].
-            1.  If |H|'s [=exposure set=] is <code>*</code>, return |C|'s [=own exposure set=].
-            1.  Return the [=set/intersection=] of |C|'s [=own exposure set=] and |H|'s
-                [=exposure set=].
+        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|,
+            return the [=exposure set intersection=] of |C| and |H|.
         1.  Set |C| to |H|.
     1.  Assert: |C| is an [=interface=], [=callback interface=] or [=namespace=].
     1.  Assert: The [{{Exposed}}] [=extended attribute=] is specified on |C|.

--- a/index.bs
+++ b/index.bs
@@ -9402,7 +9402,8 @@ The [{{Exposed}}] [=extended attribute=] must either
 [=takes a wildcard|take a wildcard=].
 Each of the identifiers mentioned must be a [=global name=] of some [=interface=] and be unique.
 
-The <dfn>own exposure set</dfn> is the [=/set=] of identifiers defined as follows:
+The <dfn>own exposure set</dfn> is either a [=/set=] of identifiers or the special value
+<code>*</code>, defined as follows:
 
 <dl class="switch">
      :  If the [{{Exposed}}] [=extended attribute=] [=takes an identifier=] |I|
@@ -9410,8 +9411,7 @@ The <dfn>own exposure set</dfn> is the [=/set=] of identifiers defined as follow
      :  If the [{{Exposed}}] [=extended attribute=] [=takes an identifier list=] |I|
      :: The [=own exposure set=] is the [=/set=] |I|.
      :  If the [{{Exposed}}] [=extended attribute=] [=takes a wildcard=]
-     :: The [=own exposure set=] is the [=/set=] of all [=global names=] of all [=interfaces=]
-        which have the [{{Global}}] [=extended attribute=].
+     :: The [=own exposure set=] is <code>*</code>.
 </dl>
 
 <p class="advisement">
@@ -9430,26 +9430,33 @@ The <dfn>own exposure set</dfn> is the [=/set=] of identifiers defined as follow
     1.  Let |H| be |C|'s [=host interface=] if |C| is an [=interface mixin member=], or null otherwise.
     1.  If |C| is an [=interface member=], [=interface mixin member=], or [=namespace member=], then:
         1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|, then:
-            1.  If |H| is set, return the [=set/intersection=] of |C|'s [=own exposure set=]
-                and |H|'s [=exposure set=].
-            1.  Otherwise, return |C|'s [=own exposure set=].
-        1.  Otherwise, set |C| to be the
+            1.  If |H| is null, return |C|'s [=own exposure set=].
+            1.  If |C|'s [=own exposure set=] is <code>*</code>, return |H|'s [=exposure set=].
+            1.  If |H|'s [=exposure set=] is <code>*</code>, return |C|'s [=own exposure set=].
+            1.  Return the [=set/intersection=] of |C|'s [=own exposure set=] and |H|'s
+                [=exposure set=].
+        1.  Set |C| to the
             [=interface=], [=partial interface=],
             [=interface mixin=], [=partial interface mixin=],
             [=namespace=], or [=partial namespace=]
             |C| is declared on.
     1.  If |C| is a [=partial interface=], [=partial interface mixin=], or [=partial namespace=], then:
         1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|, then:
-            1.  If |H| is set, return the [=set/intersection=] of |C|'s [=own exposure set=]
-                and |H|'s [=exposure set=].
-            1.  Otherwise, return |C|'s [=own exposure set=].
-        1.  Otherwise, set |C| to be the original [=interface=], [=interface mixin=], or [=namespace=]
-            definition of |C|.
+            1.  If |H| is null, return |C|'s [=own exposure set=].
+            1.  If |C|'s [=own exposure set=] is <code>*</code>, return |H|'s [=exposure set=].
+            1.  If |H|'s [=exposure set=] is <code>*</code>, return |C|'s [=own exposure set=].
+            1.  Return the [=set/intersection=] of |C|'s [=own exposure set=] and |H|'s
+                [=exposure set=].
+        1.  Set |C| to the original [=interface=], [=interface mixin=], or [=namespace=] definition
+            of |C|.
     1.  If |C| is an [=interface mixin=], then:
-        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|,
-            then return the [=set/intersection=] of |C|'s [=own exposure set=]
-            and |H|'s [=exposure set=].
-        1.  Otherwise, set |C| to |H|.
+        1.  Assert: |H| is not null.
+        1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|, then:
+            1.  If |C|'s [=own exposure set=] is <code>*</code>, return |H|'s [=exposure set=].
+            1.  If |H|'s [=exposure set=] is <code>*</code>, return |C|'s [=own exposure set=].
+            1.  Return the [=set/intersection=] of |C|'s [=own exposure set=] and |H|'s
+                [=exposure set=].
+        1.  Set |C| to |H|.
     1.  Assert: |C| is an [=interface=], [=callback interface=] or [=namespace=].
     1.  Assert: The [{{Exposed}}] [=extended attribute=] is specified on |C|.
     1.  Return |C|'s [=own exposure set=].
@@ -9503,8 +9510,8 @@ Otherwise, it is the [=host interface=]'s [=exposure set=].
     <dfn id="dfn-exposed" export>exposed</dfn> in a given [=Realm=] |realm| if the following steps
     return true:
 
-    1.  If |realm|.\[[GlobalObject]] does not implement an [=interface=]
-        that is in |construct|'s [=exposure set=], then return false.
+    1.  If |construct|'s [=exposure set=] is not <code>*</code>, and |realm|.\[[GlobalObject]] does
+        not implement an [=interface=] that is in |construct|'s [=exposure set=], then return false.
     1.  If |realm|'s [=Realm/settings object=] is not a [=secure context=], and |construct| is
         [=conditionally exposed=] on [{{SecureContext}}], then return false.
     1.  If |realm|'s [=Realm/settings object=]'s


### PR DESCRIPTION
This is fixing an issue Dan caught, where it turns out that, since the global object inside the ShadowRealm is not defined using IDL, it's not an "interface" and hence not included in any "own exposure set". To that end, it removes the "the set of all global names of all interfaces which have the [Global] extended attribute" wording, which was pretty clunky anyway.

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

CC @leobalter @littledan 

- [x] At least two implementers are interested (and none opposed):
   * I'm assuming this is fine, since `Exposed=*` needs this to work as intended.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Existing tests cover this.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …

(I still need to review which implementations, if any, need to change for this.)

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 10, 2022, 8:43 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FMs2ger%2Fwebidl%2Ff6dc5d59c2d8a0a76a2828a18c8ab31f7c952514%2Findex.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201177)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/webidl%231177.)._
</details>
