### PR TITLE
Remove the word "instances" from DOMException custom bindings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14364,7 +14364,7 @@ as defined in the [=create an interface prototype object=] abstract operation.
 
 Additionally, if an implementation gives native {{ECMAScript/Error}} objects special powers or
 nonstandard properties (such as a <code>stack</code> property),
-it should also expose those on {{DOMException}} instances.
+it should also expose those on {{DOMException}} objects.
 
 <h4 id="es-exception-objects" dfn>Exception objects</h4>
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

This prevents a possible confusion from the word "instance", as it theoretically can sound like each instance should own the property.

Also, the paragraph mentions "native Error objects" so it's natural to match that and say "DOMException objects".

See also https://github.com/whatwg/webidl/issues/1186#issuecomment-1241401986.

- [x] At least two implementers are interested (and none opposed): (N/A?)
- [x] [Tests](https://github.com/web-platform-tests/wpt/blob/a370aad338d6ed743abb4d2c6ae84a7f1058558c/webidl/ecmascript-binding/es-exceptions/DOMException-custom-bindings.any.js#L104-L119) already just checks the exposure, not how it is exposed.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: (N/A)

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1187.html" title="Last updated on Sep 9, 2022, 9:44 PM UTC (40b9848)">Preview</a> | <a href="https://whatpr.org/webidl/1187/d720ef3...40b9848.html" title="Last updated on Sep 9, 2022, 9:44 PM UTC (40b9848)">Diff</a>