### PR TITLE
Improvements to DOMException error names table

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5190,12 +5190,12 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
         </tr>
         <tr>
             <td>"<dfn id="hierarchyrequesterror" exception export><code>HierarchyRequestError</code></dfn>"</td>
-            <td>The operation would yield an incorrect [=node tree=]. [[!DOM]]</td>
+            <td>The operation would yield an incorrect [=node tree=]. [[DOM]]</td>
             <td><dfn id="dom-domexception-hierarchy_request_err" for="DOMException" const export><code>HIERARCHY_REQUEST_ERR</code></dfn>&nbsp;(3)</td>
         </tr>
         <tr>
             <td>"<dfn id="wrongdocumenterror" exception export><code>WrongDocumentError</code></dfn>"</td>
-            <td>The object is in the wrong [=document=]. [[!DOM]]</td>
+            <td>The object is in the wrong [=document=]. [[DOM]]</td>
             <td><dfn id="dom-domexception-wrong_document_err" for="DOMException" const export><code>WRONG_DOCUMENT_ERR</code></dfn>&nbsp;(4)</td>
         </tr>
         <tr>
@@ -5220,7 +5220,7 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
         </tr>
         <tr>
             <td>"<dfn id="inuseattributeerror" exception export><code>InUseAttributeError</code></dfn>"</td>
-            <td>The attribute is in use.</td>
+            <td>The attribute is in use by another [=/element=]. [[DOM]]</td>
             <td><dfn id="dom-domexception-inuse_attribute_err" for="DOMException" const export><code>INUSE_ATTRIBUTE_ERR</code></dfn>&nbsp;(10)</td>
         </tr>
         <tr>
@@ -5273,9 +5273,9 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
             <td>The operation was aborted.</td>
             <td><dfn id="dom-domexception-abort_err" for="DOMException" const export><code>ABORT_ERR</code></dfn>&nbsp;(20)</td>
         </tr>
-        <tr>
+        <tr class="deprecated">
             <td>"<dfn id="urlmismatcherror" exception export><code>URLMismatchError</code></dfn>"</td>
-            <td>The given URL does not match another URL.</td>
+            <td><strong>Deprecated.</strong></td>
             <td><dfn id="dom-domexception-url_mismatch_err" for="DOMException" const export><code>URL_MISMATCH_ERR</code></dfn>&nbsp;(21)</td>
         </tr>
         <tr>
@@ -5290,7 +5290,7 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
         </tr>
         <tr>
             <td>"<dfn id="invalidnodetypeerror" exception export><code>InvalidNodeTypeError</code></dfn>"</td>
-            <td>The supplied node is incorrect or has an incorrect ancestor for this operation.</td>
+            <td>The supplied [=node=] is incorrect or has an incorrect ancestor for this operation. [[DOM]]</td>
             <td><dfn id="dom-domexception-invalid_node_type_err" for="DOMException" const export><code>INVALID_NODE_TYPE_ERR</code></dfn>&nbsp;(24)</td>
         </tr>
         <tr>
@@ -5315,7 +5315,7 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
         </tr>
         <tr>
             <td>"<dfn id="constrainterror" exception export><code>ConstraintError</code></dfn>"</td>
-            <td>A mutation operation in a transaction failed because a constraint was not satisfied.</td>
+            <td>A mutation operation in a transaction failed because a constraint was not satisfied. [[INDEXEDDB]]</td>
             <td>—</td>
         </tr>
         <tr>
@@ -5325,17 +5325,17 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
         </tr>
         <tr>
             <td>"<dfn id="transactioninactiveerror" exception export><code>TransactionInactiveError</code></dfn>"</td>
-            <td>A request was placed against a transaction which is currently not active, or which is finished.</td>
+            <td>A request was placed against a transaction which is currently not active, or which is finished. [[INDEXEDDB]]</td>
             <td>—</td>
         </tr>
         <tr>
             <td>"<dfn id="readonlyerror" exception export><code>ReadOnlyError</code></dfn>"</td>
-            <td>The mutating operation was attempted in a "readonly" transaction.</td>
+            <td>The mutating operation was attempted in a "readonly" transaction. [[INDEXEDDB]]</td>
             <td>—</td>
         </tr>
         <tr>
             <td>"<dfn id="versionerror" exception export><code>VersionError</code></dfn>"</td>
-            <td>An attempt was made to open a database using a lower version than the existing version.</td>
+            <td>An attempt was made to open a database using a lower version than the existing version. [[INDEXEDDB]]</td>
             <td>—</td>
         </tr>
         <tr>


### PR DESCRIPTION
* Deprecate "URLMismatchError". Since https://github.com/whatwg/html/commit/b261d162b451a646d5597689f0b831a722a19182 it is no longer used by anything in the spec ecosystem.

* Make it clearer that "InUseAttributeError" and "InvalidNodeTypeError" are DOM-specific, by tweaking their descriptions and adding the [DOM] reference.

* Make it clearer that "ConstraintError", "TransactionInactiveError", "ReadOnlyError", and "VersionError" are IndexedDB-specific, by adding the [INDEXEDDB] reference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1202.html" title="Last updated on Sep 27, 2022, 10:38 AM UTC (37cfd25)">Preview</a> | <a href="https://whatpr.org/webidl/1202/b03aa9e...37cfd25.html" title="Last updated on Sep 27, 2022, 10:38 AM UTC (37cfd25)">Diff</a>