### PR TITLE
Make PaintOptions example a better role model.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5036,8 +5036,8 @@ No [=extended attributes=] are applicable to dictionaries.
         };
 
         dictionary PaintOptions {
-          DOMString? fillPattern = "black";
-          DOMString? strokePattern = null;
+          DOMString fillPattern = "black";
+          DOMString strokePattern;
           Point position;
         };
 
@@ -5059,10 +5059,12 @@ No [=extended attributes=] are applicable to dictionaries.
         ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) });
     </pre>
 
-    Both fillPattern and strokePattern are given [=dictionary member/default values=],
-    so if they are omitted, the definition of drawRectangle can assume that they
-    have the given default values and not include explicit wording to handle
-    their non-presence.
+    The members of <code class="idl">PaintOptions</code> are [=dictionary member/optional=].
+    If <code class="idl">fillPattern</code> is omitted, the definition of
+    <code class="idl">drawRectangle</code> can assume that it has the given default values
+    and not include explicit wording to handle its omission.
+    <code class="idl">drawRectangle</code> needs to explicitly handle the case where
+    <code class="idl">strokePattern</code> and <code class="idl">position</code> are omitted.
 
 </div>
 


### PR DESCRIPTION
Do not have members that are both optional and nullable.

Fixes #1204.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1205.html" title="Last updated on Sep 29, 2022, 6:59 AM UTC (5dcc4d0)">Preview</a> | <a href="https://whatpr.org/webidl/1205/9e4ce33...5dcc4d0.html" title="Last updated on Sep 29, 2022, 6:59 AM UTC (5dcc4d0)">Diff</a>