### PR TITLE
Fix typo - s/an/a before "NotAllowed"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,3 +1,4 @@
+Refreshing PR.
 <pre class="metadata">
 Group: WHATWG
 H1: Web IDL

--- a/index.bs
+++ b/index.bs
@@ -5140,7 +5140,7 @@ entails in the ECMAScript language binding.
     To throw a new {{DOMException}} with [=error name=] "{{NotAllowedError!!exception}}":
 
     <blockquote>
-        [=exception/Throw=] an "{{NotAllowedError!!exception}}" {{DOMException}}.
+        [=exception/Throw=] a "{{NotAllowedError!!exception}}" {{DOMException}}.
     </blockquote>
 
     To create a new {{DOMException}} with [=error name=] "{{SyntaxError!!exception}}":

--- a/index.bs
+++ b/index.bs
@@ -1,4 +1,3 @@
-Refreshing PR.
 <pre class="metadata">
 Group: WHATWG
 H1: Web IDL


### PR DESCRIPTION
Refresh
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1209.html" title="Last updated on Oct 13, 2022, 7:56 AM UTC (b2700b8)">Preview</a> | <a href="https://whatpr.org/webidl/1209/bf88a5a...b2700b8.html" title="Last updated on Oct 13, 2022, 7:56 AM UTC (b2700b8)">Diff</a>