### PR TITLE
"Quoted terminal symbols" are now monospaced

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14896,12 +14896,12 @@ text is “<span class="input">a1</span>”, it is tokenized as a single <emu-t 
 and not as a separate <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> and <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>.
 If the longest possible match could match one of the above named terminal symbols or
 one of the other terminal symbols from the grammar, it must be tokenized as the latter.
-Thus, the input text “<span class="input">long</span>” is tokenized as the quoted terminal symbol
+Thus, the input text “<span class="input">long</span>” is tokenized as the terminal symbol
 <emu-t>long</emu-t> rather than an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> called "<code>long</code>",
-and “<span class="input">.</span>” is tokenized as the quoted terminal symbol
+and “<span class="input">.</span>” is tokenized as the terminal symbol
 <emu-t>.</emu-t> rather than an <emu-t class="regex"><a href="#prod-other">other</a></emu-t>.
 
-The IDL syntax is case sensitive, both for the quoted terminal symbols
+The IDL syntax is case sensitive, both for the monospaced terminal symbols
 used in the grammar and the values used for
 <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as


### PR DESCRIPTION
Fixes #976

Some other candidates are there, but I think the term `monospaced` is the most intuitive when looking at the grammar:

>*CallbackOrInterfaceOrMixin* `::`
>    `callback` *CallbackRestOrInterface*
>    `interface` *InterfaceOrMixin*

It's clear which are the monospaced terminal symbols.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1216.html" title="Last updated on Oct 13, 2022, 6:22 AM UTC (2bf7d7c)">Preview</a> | <a href="https://whatpr.org/webidl/1216/bc7cb7a...2bf7d7c.html" title="Last updated on Oct 13, 2022, 6:22 AM UTC (2bf7d7c)">Diff</a>