### PR TITLE
Add OptOutError to the error names list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5339,6 +5339,11 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
             <td>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.</td>
             <td>—</td>
         </tr>
+        <tr>
+            <td>"<dfn id="optouterror" exception export><code>OptOutError</code></dfn>"</td>
+            <td>User opted out of the process.</td>
+            <td>—</td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
This PR adds a new OptOutError to the DOMException error names list. We plan to use this error name in the Secure Payment Confirmation API (see issue #1168). Since we don't need any additional attributes (i.e., we don't need a new class interface to extend DOMException), a new error name will suffice. The error name is generic so that it can be used by other APIs with similar use cases.

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * In the short term, this error name will be used by the Secure Payment Confirmation API implemented in Chrome, and can be used in a similar fashion by other APIs.
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Usage of the error name will be tested by APIs (e.g. Secure Payment Confirmation) that use it.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1383295
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed:
   * Will open a PR to add this to https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
