### PR TITLE
Fix getter name for maplike/setlike size

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12754,7 +12754,7 @@ with the following characteristics:
 
     The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-    The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>size</code>".
+    The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>get size</code>".
 
 
 <h5 id="es-map-iterator" oldids="es-iterator, es-iterators">@@iterator</h5>
@@ -13064,7 +13064,7 @@ with the following characteristics:
 
     The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-    The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>size</code>".
+    The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>get size</code>".
 
 
 <h5 id="es-set-iterator">@@iterator</h5>


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Everyone already implements this correctly
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/36950
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
   * Deno: Will comment on https://github.com/denoland/deno/issues/16068
   * Node.js: N/A
   * webidl2.js: N/A
   * widlparser: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1232.html" title="Last updated on Nov 15, 2022, 5:23 AM UTC (379aa27)">Preview</a> | <a href="https://whatpr.org/webidl/1232/7e9e8e4...379aa27.html" title="Last updated on Nov 15, 2022, 5:23 AM UTC (379aa27)">Diff</a>