### PR TITLE
setlike.add() is meant to return the setlike. Fixes #1268

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13067,7 +13067,7 @@ with the following characteristics:
         1.  Let |value| be |valueArg| [=converted to an IDL value=] of type |valueType|.
         1.  If |value| is -0, set |value| to +0.
         1.  [=set/Append=] |value| to |set|.
-        1.  Return |value| [=converted to an ECMAScript value=].
+        1.  Return |O|.
     </div>
 
 The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.


### PR DESCRIPTION
In #1138 I accidentally made setlike's add() return the added value, like delete(). It originally returned the setlike itself. This PR returns the spec to the original behavior.

skipping the checklist since this is just returning the spec's behavior to how it was before the #1138 PR, which was not *intended* to change this aspect.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1269.html" title="Last updated on Feb 28, 2023, 8:51 PM UTC (19c68d0)">Preview</a> | <a href="https://whatpr.org/webidl/1269/50afeeb...19c68d0.html" title="Last updated on Feb 28, 2023, 8:51 PM UTC (19c68d0)">Diff</a>