### PR TITLE
Fix links, remove as many anchor definitions as possible

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4927,7 +4927,7 @@ is identified by one of the following types:
 *   <dfn exception>URIError</dfn>
 
 These correspond to all of the ECMAScript [=ECMAScript/error objects=]
-(apart from {{SyntaxError}} and {{Error}},
+(apart from <l spec=ecmascript>{{SyntaxError}}</l> and {{Error}},
 which are deliberately omitted as they are reserved for use
 by the ECMAScript parser and by authors, respectively).
 The meaning of each [=simple exception=] matches
@@ -4996,10 +4996,10 @@ for {{DOMException}}, a description, and legacy code values.
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
 Note: Don't confuse the "{{SyntaxError!!exception}}" {{DOMException}} defined here
-with ECMAScript's {{SyntaxError}}.
+with ECMAScript's <l spec=ecmascript>{{SyntaxError}}</l>.
 "{{SyntaxError!!exception}}" {{DOMException}} is used to report parsing errors in web APIs,
 for example when parsing selectors,
-while the ECMAScript {{SyntaxError}} is reserved for the ECMAScript parser.
+while the ECMAScript <l spec=ecmascript>{{SyntaxError}}</l> is reserved for the ECMAScript parser.
 To help disambiguate this further,
 always favor the "{{SyntaxError!!exception}}" {{DOMException}} notation
 over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[DOM]]

--- a/index.bs
+++ b/index.bs
@@ -4,6 +4,7 @@ H1: Web IDL
 Shortname: webidl
 Text Macro: TWITTER webidl
 Text Macro: LATESTRD 2022-09
+Text Macro: COMMIT-SHA foo
 Abstract: This standard defines an interface definition language, Web IDL, that can be used to describe interfaces that
 Abstract: are intended to be implemented in web browsers.
 Translation: ja https://triple-underscore.github.io/WebIDL-ja.html
@@ -12,16 +13,14 @@ Complain About: accidental-2119 no
 
 <pre class="link-defaults">
 spec: infra; type: dfn; text: list
-spec: ecma-262; type: dfn; for: /; text: internal method
-spec: ecma-262; type: dfn; for: /; text: internal slot
-spec: ecma-262; type: dfn; for: /; text:realm
-spec:wasm-js-api-2;
-    type:interface; text:Memory
-    type:attribute; text:buffer; for:Memory
+spec: ecmascript; type: dfn;
+    for: ECMAScript;
+        text: constructor
+        text: realm
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
+urlPrefix: https://tc39.es/ecma262/; spec: ecmascript
     type: method; for: ECMAScript
         text: JSON.stringify(); url: sec-json.stringify
         text: %Array.prototype.entries%; url: sec-array.prototype.entries
@@ -30,79 +29,12 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
         text: %Array.prototype.values%; url: sec-array.prototype.values
         text: %Promise.reject%; url: sec-promise.reject
         text: %Promise.prototype.then%; url: sec-promise.prototype.then
-        text: all(); for: Promise; url: #sec-promise.all
     type: argument
         text: NewTarget; url: sec-built-in-function-objects
     type: abstract-op
-        text: AllocateArrayBuffer; url: sec-allocatearraybuffer
-        text: ArrayCreate; url: sec-arraycreate
-        text: Call; url: sec-call
-        text: CanonicalNumericIndexString; url: sec-canonicalnumericindexstring
         text: Completion; url: sec-completion-record-specification-type
-        text: Construct; url: sec-construct
-        text: CreateArrayFromList; url: sec-createarrayfromlist
-        text: CreateArrayIterator; url: sec-createarrayiterator
-        text: CreateBuiltinFunction; url: sec-createbuiltinfunction
-        text: CreateDataProperty; url: sec-createdataproperty
-        text: CreateIteratorFromClosure; url: sec-createiteratorfromclosure
-        text: CreateIterResultObject; url: sec-createiterresultobject
-        text: CreateMapIterator; url: sec-createmapiterator
-        text: CreateMethodProperty; url: sec-createmethodproperty
-        text: CreateSetIterator; url: sec-createsetiterator
-        text: DefinePropertyOrThrow; url: sec-definepropertyorthrow
-        text: DetachArrayBuffer; url: sec-detacharraybuffer
-        for: Environment Record; url: table-abstract-methods-of-environment-records
-            text: SetMutableBinding
-            text: CreateMutableBinding
-            text: InitializeBinding
-        text: FromPropertyDescriptor; url: sec-frompropertydescriptor
-        text: GeneratorYield; url: sec-generatoryield
-        text: Get; url: sec-get-o-p
-        text: GetFunctionRealm; url: sec-getfunctionrealm
-        text: GetIterator; url: sec-getiterator
-        text: GetMethod; url: sec-getmethod
-        text: GetValueFromBuffer; url: sec-getvaluefrombuffer
-        text: IfAbruptRejectPromise; url: sec-ifabruptrejectpromise
-        text: IsArray; url: sec-isarray
-        text: IsAccessorDescriptor; url: sec-isaccessordescriptor
-        text: IsCallable; url: sec-iscallable
-        text: IsConstructor; url: sec-isconstructor
-        text: IsDataDescriptor; url: sec-isdatadescriptor
-        text: IsDetachedBuffer; url: sec-isdetachedbuffer
         text: IsInteger; url: sec-isinteger
-        text: IsSharedArrayBuffer; url: sec-issharedarraybuffer
-        text: IteratorStep; url: sec-iteratorstep
-        text: IteratorValue; url: sec-iteratorvalue
-        text: MakeBasicObject; url: sec-makebasicobject
-        text: NewModuleEnvironment; url: sec-newmoduleenvironment
-        text: NewPromiseCapability; url: sec-newpromisecapability
-        text: NormalCompletion; url: sec-normalcompletion
-        text: OrdinaryDefineOwnProperty; url: sec-ordinarydefineownproperty
-        text: OrdinaryGetOwnProperty; url: sec-ordinarygetownproperty
-        text: OrdinaryObjectCreate; url: sec-ordinaryobjectcreate
-        text: OrdinaryPreventExtensions; url: sec-ordinarypreventextensions
-        text: OrdinarySetWithOwnDescriptor; url: sec-ordinarysetwithowndescriptor
-        text: PerformPromiseThen; url: sec-performpromisethen
-        text: ProxyCreate; url: sec-proxycreate
-        text: Set; url: sec-set-o-p-v-throw
-        text: SetFunctionLength; url: sec-setfunctionlength
-        text: SetFunctionName; url: sec-setfunctionname
-        text: SetImmutablePrototype; url: sec-set-immutable-prototype
-        text: SetIntegrityLevel; url: sec-setintegritylevel
-        text: SetValueInBuffer; url: sec-setvalueinbuffer
-        text: ToBigInt; url: #sec-tobigint
-        text: ToBoolean; url: sec-toboolean
-        text: ToInt32; url: sec-toint32
-        text: ToNumber; url: sec-tonumber
-        text: ToNumeric; url: sec-tonumeric
-        text: ToObject; url: sec-toobject
-        text: ToPropertyDescriptor; url: sec-topropertydescriptor
-        text: ToPropertyKey; url: sec-topropertykey
-        text: ToString; url: sec-tostring
-        text: ToUint16; url: sec-touint16
-        text: ToUint32; url: sec-touint32
         text: Type; url: sec-ecmascript-data-types-and-values
-        text: Yield; url: sec-yield
         text: abs; url: eqn-abs
         text: floor; url: eqn-floor
         text: max; url: eqn-max
@@ -116,47 +48,24 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
             text: ?
         text: ECMA-262 Immutable Prototype Exotic Objects; url: sec-immutable-prototype-exotic-objects
         text: abrupt completion; url: sec-completion-record-specification-type
-        text: array index; url: array-index
         text: array iterator object; url: sec-array-iterator-objects
         text: built-in function object; url: sec-built-in-function-objects
         text: callable; for: ECMAScript; url: sec-iscallable
         text: Completion Record; url: sec-completion-record-specification-type
-        text: constructor; url: constructor
         text: conventions; for: ECMAScript; url: sec-algorithm-conventions
         text: current realm; url: current-realm
-        text: ECMAScript code execution context; url: sec-execution-contexts
-        for: ECMAScript code execution context; url: table-additional-state-components-for-ecmascript-code-execution-contexts
-            text: LexicalEnvironment
-            text: VariableEnvironment
         text: element; for: ECMAScript String; url: sec-ecmascript-language-types-string-type
         text: enumerable; url: sec-property-attributes
-        text: EnvironmentRecord; for: Lexical Environment; url: sec-environment-records
         text: equally close values; url: sec-ecmascript-language-types-number-type
         text: error objects; for: ECMAScript; url: sec-error-objects
-        for: Execution context; url: table-state-components-for-all-execution-contexts
-            text: Function
-            text: Realm
-            text: ScriptOrModule
-        text: execution context stack; url: execution-context-stack
-        text: function object; url: function-object
-        text: immutable prototype exotic object; url: sec-immutable-prototype-exotic-objects
         url: sec-object-internal-methods-and-internal-slots
             text: internal method
             text: internal slot
-        text: Module Record; url: sec-abstract-module-records
-        text: Module Record Fields; url: table-module-record-fields
-        text: Number type; url: sec-ecmascript-language-types-number-type
         for: ordinary object; url: sec-ordinary-object-internal-methods-and-internal-slots
             text: internal method
             text: internal slot
         text: own property; url: sec-own-property
         text: PromiseCapability; url: sec-promisecapability-records
-        text: Property Descriptor; url: sec-property-descriptor-specification-type
-        text: Proxy exotic object; url: sec-proxy-object-internal-methods-and-internal-slots
-        text: Source Text Module Record; url: sec-source-text-module-records
-        text: realm; url: realm
-        text: ResolvedBinding Record; url: resolvedbinding-record
-        text: running execution context; url: running-execution-context
         text: element size; url: table-the-typedarray-constructors
 urlPrefix: https://tc39.es/proposal-resizablearraybuffer/; spec: RESIZABLE-BUFFERS-PROPOSAL
     type: abstract-op
@@ -8499,21 +8408,21 @@ that correspond to the union's [=member types=].
             [=implements=], then return the IDL value that is a reference to the object |V|.
         1.  If |types| includes {{object}}, then return the IDL value
             that is a reference to the object |V|.
-    1.  If <a abstract-op>Type</a>(|V|) is Object and |V| has an \[[ArrayBufferData]] [=internal slot=], then:
+    1.  If <a abstract-op>Type</a>(|V|) is Object and |V| has an \[[ArrayBufferData]] [=/internal slot=], then:
         1.  If |types| includes {{ArrayBuffer}}, then return the
             result of [=converted to an IDL value|converting=]
             |V| to {{ArrayBuffer}}.
         1.  If |types| includes {{object}}, then return the IDL value
             that is a reference to the object |V|.
-    1.  If <a abstract-op>Type</a>(|V|) is Object and |V| has a \[[DataView]] [=internal slot=], then:
+    1.  If <a abstract-op>Type</a>(|V|) is Object and |V| has a \[[DataView]] [=/internal slot=], then:
         1.  If |types| includes {{DataView}}, then return the
             result of [=converted to an IDL value|converting=]
             |V| to {{DataView}}.
         1.  If |types| includes {{object}}, then return the IDL value
             that is a reference to the object |V|.
-    1.  If <a abstract-op>Type</a>(|V|) is Object and |V| has a \[[TypedArrayName]] [=internal slot=], then:
+    1.  If <a abstract-op>Type</a>(|V|) is Object and |V| has a \[[TypedArrayName]] [=/internal slot=], then:
         1.  If |types| includes a [=typed array type=]
-            whose name is the value of |V|'s \[[TypedArrayName]] [=internal slot=], then return the
+            whose name is the value of |V|'s \[[TypedArrayName]] [=/internal slot=], then return the
             result of [=converted to an IDL value|converting=]
             |V| to that type.
         1.  If |types| includes {{object}}, then return the IDL value
@@ -8627,7 +8536,7 @@ are represented by objects of the corresponding ECMAScript class, with the follo
     to an IDL {{ArrayBuffer}} value by running the following algorithm:
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
-        or |V| does not have an \[[ArrayBufferData]] [=internal slot=],
+        or |V| does not have an \[[ArrayBufferData]] [=/internal slot=],
         then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
@@ -8647,7 +8556,7 @@ are represented by objects of the corresponding ECMAScript class, with the follo
     to an IDL {{DataView}} value by running the following algorithm:
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
-        or |V| does not have a \[[DataView]] [=internal slot=],
+        or |V| does not have a \[[DataView]] [=/internal slot=],
         then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
@@ -8680,7 +8589,7 @@ are represented by objects of the corresponding ECMAScript class, with the follo
 
     1.  Let |T| be the IDL type |V| is being converted to.
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
-        or |V| does not have a \[[TypedArrayName]] [=internal slot=]
+        or |V| does not have a \[[TypedArrayName]] [=/internal slot=]
         with a value equal to |T|'s name,
         then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
@@ -8739,7 +8648,7 @@ a reference to the same object that the IDL value represents.
     1.  Let |esArrayBuffer| be |esBufferSource|.
     1.  Let |offset| be 0.
     1.  Let |length| be 0.
-    1.  If |esBufferSource| has a \[[ViewedArrayBuffer]] [=internal slot=], then:
+    1.  If |esBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=], then:
         1.  Set |esArrayBuffer| to |esBufferSource|.\[[ViewedArrayBuffer]].
         1.  Set |offset| to |esBufferSource|.\[[ByteOffset]].
         1.  Set |length| to |esBufferSource|.\[[ByteLength]].
@@ -10960,7 +10869,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             then remove from |S| all other entries.
 
-        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is Object, |V| has an \[[ArrayBufferData]] [=internal slot=], and
+        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is Object, |V| has an \[[ArrayBufferData]] [=/internal slot=], and
             there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   {{ArrayBuffer}}
             *   {{object}}
@@ -10971,7 +10880,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             then remove from |S| all other entries.
 
-        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is Object, |V| has a \[[DataView]] [=internal slot=], and
+        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is Object, |V| has a \[[DataView]] [=/internal slot=], and
             there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   {{DataView}}
             *   {{object}}
@@ -10982,10 +10891,10 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             then remove from |S| all other entries.
 
-        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is Object, |V| has a \[[TypedArrayName]] [=internal slot=], and
+        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is Object, |V| has a \[[TypedArrayName]] [=/internal slot=], and
             there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   a [=typed array type=] whose name
-                is equal to the value of |V|'s \[[TypedArrayName]] [=internal slot=]
+                is equal to the value of |V|'s \[[TypedArrayName]] [=/internal slot=]
             *   {{object}}
             *   a [=nullable type|nullable=] version of either of the above types
             *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
@@ -11494,7 +11403,7 @@ Issue: Define those properties imperatively instead.
     (since it does not exist as <code>window.Foo</code>).  However, an instance
     of <code class="idl">Foo</code> can expose the interface prototype
     object by calling its \[[GetPrototypeOf]]
-    [=internal method=] – <code>Object.getPrototypeOf(window.foo)</code> in
+    [=/internal method=] – <code>Object.getPrototypeOf(window.foo)</code> in
     this example.
 
 </div>
@@ -12246,7 +12155,7 @@ then there must exist a property with the following characteristics:
 
 A <dfn id="dfn-default-iterator-object" export>default iterator object</dfn> for a given
 [=interface=], target and iteration kind
-is an object whose \[[Prototype]] [=internal slot=] is the
+is an object whose \[[Prototype]] [=/internal slot=] is the
 [=iterator prototype object=]
 for the [=interface=].
 
@@ -12280,7 +12189,7 @@ is an object that exists for every interface that has a
 prototype for [=default iterator objects=]
 for the interface.
 
-The \[[Prototype]] [=internal slot=] of an [=iterator prototype object=]
+The \[[Prototype]] [=/internal slot=] of an [=iterator prototype object=]
 must be {{%IteratorPrototype%}}.
 
 <div algorithm>
@@ -12460,7 +12369,7 @@ and the string "<code> Iterator</code>".
 
 A <dfn id="dfn-default-asynchronous-iterator-object" export>default asynchronous iterator
 object</dfn> for a given [=interface=], target and iteration kind is an object whose \[[Prototype]]
-[=internal slot=] is the [=asynchronous iterator prototype object=] for the [=interface=].
+[=/internal slot=] is the [=asynchronous iterator prototype object=] for the [=interface=].
 
 A [=default asynchronous iterator object=] has internal values:
 
@@ -12485,7 +12394,7 @@ for a given [=interface=] is an object that exists for every interface that has 
 [=asynchronously iterable declaration=].
 It serves as the prototype for [=default asynchronous iterator objects=] for the interface.
 
-The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype object=] must be
+The \[[Prototype]] [=/internal slot=] of an [=asynchronous iterator prototype object=] must be
 {{%AsyncIteratorPrototype%}}.
 
 <div algorithm="to invoke the next property of asynchronous iterators">
@@ -13390,7 +13299,7 @@ the realm given as an argument.
 The [=realm=] that a given [=platform object=]
 is associated with can <dfn id="dfn-change-global-environment" for="realm" export>change</dfn> after it has been created.  When
 the [=realm=] associated with a platform object is changed, its
-\[[Prototype]] [=internal slot=] must be immediately
+\[[Prototype]] [=/internal slot=] must be immediately
 updated to be the [=interface prototype object=]
 of the [=primary interface=]
 from the [=platform object=]'s newly associated [=realm=].
@@ -14278,7 +14187,7 @@ The [=class string=] of a [=namespace object=] is the [=namespace=]'s [=identifi
 <h4 id="es-DOMException-specialness" oldids="es-DOMException-constructor-object, es-DOMException-prototype-object">{{DOMException}} custom bindings</h4>
 
 In the ECMAScript binding, the [=interface prototype object=] for {{DOMException}}
-has its \[[Prototype]] [=internal slot=] set to the intrinsic object {{%Error.prototype%}},
+has its \[[Prototype]] [=/internal slot=] set to the intrinsic object {{%Error.prototype%}},
 as defined in the [=create an interface prototype object=] abstract operation.
 
 Additionally, if an implementation gives native {{Error}} objects special powers or

--- a/index.bs
+++ b/index.bs
@@ -12,72 +12,16 @@ Complain About: accidental-2119 no
 
 <pre class="link-defaults">
 spec: infra; type: dfn; text: list
-spec: url; type: interface; text: URL
-spec: dom; type: interface; text: Document
 spec: ecma-262; type: dfn; for: /; text: internal method
 spec: ecma-262; type: dfn; for: /; text: internal slot
 spec: ecma-262; type: dfn; for: /; text:realm
+spec:wasm-js-api-2;
+    type:interface; text:Memory
+    type:attribute; text:buffer; for:Memory
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/; spec: WEBGL_compressed_texture_astc
-    type: interface; text: WEBGL_compressed_texture_astc
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/; spec: WEBGL_compressed_texture_s3tc_srgb
-    type: interface; text: WEBGL_compressed_texture_s3tc_srgb
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/; spec: WEBGL_draw_buffers
-    type: interface; text: WEBGL_draw_buffers
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/; spec: WEBGL_lose_context
-    type: interface; text: WEBGL_lose_context
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/; spec: ANGLE_instanced_arrays
-    type: interface; text: ANGLE_instanced_arrays
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/; spec: EXT_blend_minmax
-    type: interface; text: EXT_blend_minmax
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/; spec: EXT_color_buffer_float
-    type: interface; text: EXT_color_buffer_float
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/; spec: EXT_disjoint_timer_query
-    type: interface; text: EXT_disjoint_timer_query
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/; spec: OES_standard_derivatives
-    type: interface; text: OES_standard_derivatives
-urlPrefix: https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/; spec: OES_vertex_array_object
-    type: interface; text: OES_vertex_array_object
-urlPrefix: https://www.w3.org/TR/geolocation-API/; spec: GEOLOCATION-API
-    type: interface
-        text: Geolocation; url: geolocation;
-        text: Coordinates; url: coordinates;
-        text: Position; url: position;
-        text: PositionError; url: position-error;
-urlPrefix: https://w3c.github.io/deviceorientation/spec-source-orientation.html; spec: ORIENTATION-EVENT
-    type: interface
-        text: DeviceRotationRate; url: device_rotation_rate;
-        text: DeviceAcceleration; url: device_acceleration;
-urlPrefix: https://w3c.github.io/mediacapture-main/; spec: MEDIACAPTURE-STREAMS
-    type: interface
-        text: ConstrainablePattern; url: dom-constrainablepattern;
 urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
-    type: interface; for: ECMAScript
-        text: Array; url: sec-array-objects
-        text: ArrayBuffer; url: sec-arraybuffer-objects
-        text: DataView; url: sec-dataview-objects
-        text: Map; url: sec-map-objects
-        text: Promise; url: sec-promise-objects
-        text: Set; url: sec-set-objects
-        text: SharedArrayBuffer; url: sec-sharedarraybuffer-objects
-        text: %AsyncIteratorPrototype%; url: sec-asynciteratorprototype
-        text: %ArrayBuffer%; url: sec-arraybuffer-constructor
-        text: %Array.prototype%; url: sec-properties-of-the-array-prototype-object
-        text: %Error.prototype%; url: sec-properties-of-the-error-prototype-object
-        text: %Function.prototype%; url: sec-properties-of-the-function-prototype-object
-        text: %IteratorPrototype%; url: sec-%25iteratorprototype%25-object
-        text: %Map.prototype%; url: sec-properties-of-the-map-prototype-object
-        text: %MapIteratorPrototype%; url: sec-%25mapiteratorprototype%25-object
-        text: %Object.prototype%; url: sec-properties-of-the-object-prototype-object
-        text: %Promise%; url: sec-promise-constructor
-        text: %Set.prototype%; url: sec-properties-of-the-set-prototype-object
-        text: %SetIteratorPrototype%; url: sec-%25setiteratorprototype%25-object
-    type: exception; for: ECMAScript
-        text: Error; url: sec-error-objects
-        text: SyntaxError; url: sec-native-error-types-used-in-this-standard-syntaxerror
-        text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
     type: method; for: ECMAScript
         text: JSON.stringify(); url: sec-json.stringify
         text: %Array.prototype.entries%; url: sec-array.prototype.entries
@@ -87,12 +31,6 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
         text: %Promise.reject%; url: sec-promise.reject
         text: %Promise.prototype.then%; url: sec-promise.prototype.then
         text: all(); for: Promise; url: #sec-promise.all
-    type: const; for: ECMAScript
-        url: sec-well-known-symbols
-            text: @@asyncIterator
-            text: @@iterator
-            text: @@toStringTag
-            text: @@unscopables
     type: argument
         text: NewTarget; url: sec-built-in-function-objects
     type: abstract-op
@@ -176,15 +114,11 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
         url: sec-returnifabrupt-shorthands
             text: !
             text: ?
-        text: ECMA-262 Algorithm Conventions; url: sec-algorithm-conventions
-        text: ECMA-262 Ordinary Object Internal Methods and Internal Slots; url: sec-ordinary-object-internal-methods-and-internal-slots
-        text: ECMA-262 Built-in Function Objects; url: sec-built-in-function-objects
         text: ECMA-262 Immutable Prototype Exotic Objects; url: sec-immutable-prototype-exotic-objects
         text: abrupt completion; url: sec-completion-record-specification-type
         text: array index; url: array-index
         text: array iterator object; url: sec-array-iterator-objects
         text: built-in function object; url: sec-built-in-function-objects
-        text: BigInt; url: #sec-ecmascript-language-types-bigint-type
         text: callable; for: ECMAScript; url: sec-iscallable
         text: Completion Record; url: sec-completion-record-specification-type
         text: constructor; url: constructor
@@ -212,7 +146,6 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
         text: Module Record; url: sec-abstract-module-records
         text: Module Record Fields; url: table-module-record-fields
         text: Number type; url: sec-ecmascript-language-types-number-type
-        text: Object; for: ECMAScript; url: sec-object-type
         for: ordinary object; url: sec-ordinary-object-internal-methods-and-internal-slots
             text: internal method
             text: internal slot
@@ -4432,7 +4365,7 @@ the map entries.
 
 Note: In the ECMAScript language binding, the API for interacting
 with the map entries is similar to that available on ECMAScript
-{{ECMAScript/Map}} objects.  If the <emu-t>readonly</emu-t>
+{{Map}} objects.  If the <emu-t>readonly</emu-t>
 keyword is used, this includes <code class="idl">entries</code>,
 <code class="idl">forEach</code>, <code class="idl">get</code>,
 <code class="idl">has</code>, <code class="idl">keys</code>,
@@ -4527,7 +4460,7 @@ the set entries.
 
 Note: In the ECMAScript language binding, the API for interacting
 with the set entries is similar to that available on ECMAScript
-{{ECMAScript/Set}} objects.  If the <emu-t>readonly</emu-t>
+{{Set}} objects.  If the <emu-t>readonly</emu-t>
 keyword is used, this includes <code class="idl">entries</code>,
 <code class="idl">forEach</code>, <code class="idl">has</code>,
 <code class="idl">keys</code>, <code class="idl">values</code>,
@@ -5085,7 +5018,7 @@ is identified by one of the following types:
 *   <dfn exception>URIError</dfn>
 
 These correspond to all of the ECMAScript [=ECMAScript/error objects=]
-(apart from {{ECMAScript/SyntaxError}} and {{ECMAScript/Error}},
+(apart from {{SyntaxError}} and {{Error}},
 which are deliberately omitted as they are reserved for use
 by the ECMAScript parser and by authors, respectively).
 The meaning of each [=simple exception=] matches
@@ -5154,10 +5087,10 @@ for {{DOMException}}, a description, and legacy code values.
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
 Note: Don't confuse the "{{SyntaxError!!exception}}" {{DOMException}} defined here
-with ECMAScript's {{ECMAScript/SyntaxError}}.
+with ECMAScript's {{SyntaxError}}.
 "{{SyntaxError!!exception}}" {{DOMException}} is used to report parsing errors in web APIs,
 for example when parsing selectors,
-while the ECMAScript {{ECMAScript/SyntaxError}} is reserved for the ECMAScript parser.
+while the ECMAScript {{SyntaxError}} is reserved for the ECMAScript parser.
 To help disambiguate this further,
 always favor the "{{SyntaxError!!exception}}" {{DOMException}} notation
 over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[DOM]]
@@ -6936,8 +6869,8 @@ in ECMAScript, as defined by the <cite>ECMAScript Language Specification</cite>
 [[!ECMA-262]].
 
 Unless otherwise specified, objects defined in this section are ordinary objects as described in
-[=ECMA-262 Ordinary object internal methods and internal slots=], and if the
-object is a [=function object=], [=ECMA-262 Built-in function objects=].
+[[ecmascript#sec-ordinary-object-internal-methods-and-internal-slots]], and if the
+object is a [=function object=], [[ecmascript#sec-built-in-function-objects]].
 
 This section may redefine certain internal methods and internal slots of objects. Other
 specifications may also override the definitions of any internal method or internal slots of a
@@ -6973,8 +6906,7 @@ with PropertyDescriptor{\[[Writable]]: <emu-val>false</emu-val>,
 \[[Value]]: |classString|}.
 
 <p id="ecmascript-abstractop">
-    Algorithms in this section use the conventions described in [=ECMA-262
-    Algorithm conventions=], such as the use of steps and substeps, the use of mathematical
+    Algorithms in this section use the conventions described in [[ecmascript#sec-algorithm-conventions]], such as the use of steps and substeps, the use of mathematical
     operations, and so on.  This section may also reference abstract operations
     and notations defined in other parts of ECMA-262.
 </p>
@@ -7171,7 +7103,7 @@ ECMAScript value type.
 <h4 id="es-integer-types">Integer types</h4>
 
 Mathematical operations used in this section,
-including those defined in [=ECMA-262 Algorithm conventions=],
+including those defined in [[ecmascript#sec-algorithm-conventions]],
 are to be understood as computing exact mathematical results
 on mathematical real numbers.
 
@@ -7390,10 +7322,10 @@ In effect, where <var ignore>x</var> is a Number value,
     1.  If the conversion is to an IDL type [=extended attribute associated with|associated with=]
         the [{{EnforceRange}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-            then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+            then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Set |x| to <a abstract-op>IntegerPart</a>(|x|).
         1.  If |x| &lt; |lowerBound| or |x| &gt; |upperBound|,
-            then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+            then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Return |x|.
     1.  If |x| is not <emu-val>NaN</emu-val> and the conversion is to an IDL type
         [=extended attribute associated with|associated with=] the [{{Clamp}}] extended attribute,
@@ -7421,7 +7353,7 @@ In effect, where <var ignore>x</var> is a Number value,
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |S| be the set of finite IEEE 754 single-precision floating
         point values except −0, but with two special values added: 2<sup>128</sup> and
         −2<sup>128</sup>.
@@ -7430,7 +7362,7 @@ In effect, where <var ignore>x</var> is a Number value,
         <em>even significand</em> if there are two [=equally close values=].
         (The two special values 2<sup>128</sup> and −2<sup>128</sup>
         are considered to have even significands for this purpose.)
-    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If |y| is +0 and |x| is negative, return −0.
     1.  Return |y|.
 </div>
@@ -7494,7 +7426,7 @@ value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{double}} value
         that represents the same numeric value as |x|.
 </div>
@@ -7556,7 +7488,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{bigint}} value to an ECMAScript value is a BigInt:
 
-    1.  Return the [=BigInt=] value that represents the same numeric value as the IDL {{bigint}}
+    1.  Return the {{BigInt}} value that represents the same numeric value as the IDL {{bigint}}
         value.
 </div>
 
@@ -7605,7 +7537,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
     1.  Let |x| be [=?=] <a abstract-op>ToString</a>(|V|).
     1.  If the value of any [=ECMAScript String/element=]
-        of |x| is greater than 255, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        of |x| is greater than 255, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return an IDL {{ByteString}} value
         whose length is the length of |x|, and where the value of each element is
         the value of the corresponding element of |x|.
@@ -7655,7 +7587,7 @@ values are represented by ECMAScript Object values.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{object}} value by running the following algorithm:
 
-    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{object}} value that is a reference to the same object as |V|.
 </div>
 
@@ -7675,7 +7607,7 @@ IDL {{symbol}} values are represented by ECMAScript Symbol values.
     An ECMAScript value |V| is [=converted to an IDL value|converted=] to an IDL {{symbol}} value
     by running the following algorithm:
 
-    1.  If <a abstract-op>Type</a>(|V|) is not Symbol, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>Type</a>(|V|) is not Symbol, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{symbol}} value that is a reference to the same symbol as |V|.
 </div>
 
@@ -7697,7 +7629,7 @@ values are represented by ECMAScript Object values (including [=function objects
     to an IDL [=interface type=] value by running the following algorithm (where |I| is the [=interface=]):
 
     1.  If |V| [=implements=] |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
-    1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
+    1.  [=ECMAScript/Throw=] a {{TypeError}}.
 </div>
 
 <p id="interface-to-es">
@@ -7719,7 +7651,7 @@ values are represented by ECMAScript Object values (including [=function objects
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=callback interface type=] value by running the following algorithm:
 
-    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL [=callback interface type=] value that represents a reference to |V|, with
         the <a spec="HTML">incumbent settings object</a> as the [=callback context=].
 </div>
@@ -7745,7 +7677,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
     to an IDL [=dictionary type=] value by
     running the following algorithm (where |D| is the [=dictionary type=]):
 
-    1.  If <a abstract-op>Type</a>(|esDict|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>Type</a>(|esDict|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |idlDict| be an empty [=ordered map=], representing a dictionary of type |D|.
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|'s [=inherited dictionaries=],
         in order from least to most derived.
@@ -7767,7 +7699,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
                 1.  Let |idlMemberValue| be |member|'s default value.
                 1.  [=map/Set=] |idlDict|[|key|] to |idlMemberValue|.
             1.  Otherwise, if |esMemberValue| is <emu-val>undefined</emu-val> and |member| is
-                [=dictionary member/required=], then throw a {{ECMAScript/TypeError}}.
+                [=dictionary member/required=], then throw a {{TypeError}}.
     1.  Return |idlDict|.
 </div>
 
@@ -7810,7 +7742,7 @@ values.
 
     1.  Let |S| be the result of calling [=?=] <a abstract-op>ToString</a>(|V|).
     1.  If |S| is not one of |E|'s [=enumeration values=],
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the enumeration value of type |E| that is equal to |S|.
 </div>
 
@@ -7840,7 +7772,7 @@ IDL [=callback function types=] are represented by ECMAScript [=function objects
         whose type is a [=nullable type|nullable=]
         [=callback function=]
         that is annotated with [{{LegacyTreatNonObjectAsNull}}],
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL [=callback function type=] value
         that represents a reference to the same object that |V| represents, with the
         <a spec="HTML">incumbent settings object</a> as the [=callback context=].
@@ -7911,10 +7843,10 @@ ECMAScript Array values.
     to an IDL <a lt="sequence type">sequence&lt;<var ignore>T</var>&gt;</a> value as follows:
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
-        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
     1.  If |method| is <emu-val>undefined</emu-val>,
-        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]
         from |V| and |method|.
 </div>
@@ -8054,7 +7986,7 @@ ECMAScript Object values.
     to an IDL <code>[=record=]&lt;|K|, |V|></code> value as follows:
 
     1.  If <a abstract-op>Type</a>(|O|) is not Object,
-        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |result| be a new empty instance of <code>[=record=]&lt;|K|, |V|></code>.
     1.  Let |keys| be [=?=] |O|.\[[OwnPropertyKeys]]().
     1.  [=list/For each=] |key| of |keys|:
@@ -8121,7 +8053,7 @@ ECMAScript Object values.
         <tr>
             <td><code>{"😞": 1}</code></td>
             <td><code>[=record=]&lt;ByteString, double></code></td>
-            <td>{{ECMAScript/TypeError}}</td>
+            <td>{{TypeError}}</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": 1}</code></td>
@@ -8646,7 +8578,7 @@ that correspond to the union's [=member types=].
     1.  If |types| includes {{bigint}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{bigint}}.
-    1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
+    1.  [=ECMAScript/Throw=] a {{TypeError}}.
 </div>
 
 <p id="union-to-es">
@@ -8666,26 +8598,26 @@ are represented by objects of the corresponding ECMAScript class, with the follo
     <li>
         If the type is not [=extended attributes associated with|associated with=] either the
         [{{AllowResizable}}] or [{{AllowShared}}] [=extended attribute=], they can only be backed by
-        ECMAScript {{ECMAScript/ArrayBuffer}} objects |V| for which <a
+        ECMAScript {{ArrayBuffer}} objects |V| for which <a
         abstract-op>IsResizableArrayBuffer</a>(|V|) is false.
     </li>
     <li>
         If the type is [=extended attributes associated with|associated with=] the
         [{{AllowResizable}}] [=extended attribute=] but not with the [{{AllowShared}}] [=extended
-        attribute=], they can only be backed by ECMAScript {{ECMAScript/ArrayBuffer}} objects.
+        attribute=], they can only be backed by ECMAScript {{ArrayBuffer}} objects.
     </li>
     <li>
         If the type is [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=] but not with the [{{AllowResizable}}] [=extended attribute=], they
-        can only be backed by ECMAScript {{ECMAScript/ArrayBuffer}} and ECMAScript
-        {{ECMAScript/SharedArrayBuffer}} objects |V| for which <a
+        can only be backed by ECMAScript {{ArrayBuffer}} and ECMAScript
+        {{SharedArrayBuffer}} objects |V| for which <a
         abstract-op>IsResizableArrayBuffer</a>(|V|) is false.
     </li>
     <li>
         If the type is [=extended attributes associated with|associated with=] both the
         [{{AllowResizable}}] and the [{{AllowShared}}] [=extended attribute|extended attributes=],
-        they can be backed by any ECMAScript {{ECMAScript/ArrayBuffer}} or
-        {{ECMAScript/SharedArrayBuffer}} object.
+        they can be backed by any ECMAScript {{ArrayBuffer}} or
+        {{SharedArrayBuffer}} object.
     </li>
 </ul>
 
@@ -8696,15 +8628,15 @@ are represented by objects of the corresponding ECMAScript class, with the follo
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have an \[[ArrayBufferData]] [=internal slot=],
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and <a abstract-op>IsSharedArrayBuffer</a>(|V|) is true, then [=ECMAScript/throw=]
-        a {{ECMAScript/TypeError}}.
+        a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
         [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|) is true,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{ArrayBuffer}} value that is a reference
         to the same object as |V|.
 </div>
@@ -8716,15 +8648,15 @@ are represented by objects of the corresponding ECMAScript class, with the follo
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have a \[[DataView]] [=internal slot=],
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and <a abstract-op>IsSharedArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
         [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{DataView}} value that is a reference
         to the same object as |V|.
 </div>
@@ -8750,15 +8682,15 @@ are represented by objects of the corresponding ECMAScript class, with the follo
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have a \[[TypedArrayName]] [=internal slot=]
         with a value equal to |T|'s name,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and <a abstract-op>IsSharedArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
         [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL value of type |T| that is a reference to the same object as |V|.
 </div>
 
@@ -8812,8 +8744,8 @@ a reference to the same object that the IDL value represents.
         1.  Set |offset| to |esBufferSource|.\[[ByteOffset]].
         1.  Set |length| to |esBufferSource|.\[[ByteLength]].
     1.  Otherwise:
-        1.  Assert: |esBufferSource| is an {{ECMAScript/ArrayBuffer}} or
-            {{ECMAScript/SharedArrayBuffer}} object.
+        1.  Assert: |esBufferSource| is an {{ArrayBuffer}} or
+            {{SharedArrayBuffer}} object.
         1.  Set |length| to |esBufferSource|.\[[ArrayBufferByteLength]].
     1.  If [$IsDetachedBuffer$](|esArrayBuffer|) is true, then return the empty
         [=byte sequence=].
@@ -9023,11 +8955,11 @@ whose presence affects the ECMAScript binding.
 
 If the [{{AllowResizable}}] [=extended attribute=] appears on one of the [=buffer source types=] without the presence of the [{{AllowShared}}] [=extended attribute=], it
 creates a new IDL type that allows the buffer source type to be backed by an ECMAScript
-{{ECMAScript/ArrayBuffer}} that is resizable, instead of only by a fixed-length {{ECMAScript/ArrayBuffer}}.
+{{ArrayBuffer}} that is resizable, instead of only by a fixed-length {{ArrayBuffer}}.
 
 If the [{{AllowResizable}}] [=extended attribute=] and the [{{AllowShared}}] [=extended attribute=] both appear on one of the [=buffer source types=], it
 creates a new IDL type that allows the buffer source type to be additionally backed by an ECMAScript
-{{ECMAScript/SharedArrayBuffer}} that is growable.
+{{SharedArrayBuffer}} that is growable.
 
 The [{{AllowResizable}}] extended attribute must [=takes no arguments|take no arguments=].
 
@@ -9044,7 +8976,7 @@ See the <a href="#example-allowresizable-allowshared">example</a> in [[#AllowSha
 
 If the [{{AllowShared}}] [=extended attribute=] appears on one of the [=buffer source types=], it
 creates a new IDL type that allows the buffer source type to be backed by an ECMAScript
-{{ECMAScript/SharedArrayBuffer}}, instead of only by a non-shared {{ECMAScript/ArrayBuffer}}.
+{{SharedArrayBuffer}}, instead of only by a non-shared {{ArrayBuffer}}.
 
 The [{{AllowShared}}] extended attribute must [=takes no arguments|take no arguments=].
 
@@ -9071,24 +9003,24 @@ See the rules for converting ECMAScript values to IDL [=buffer source types=] in
     With this definition,
     <ul>
         <li>
-            A call to <code>writeInto</code> with a resizable {{ECMAScript/ArrayBuffer}} instance, a
-            {{ECMAScript/SharedArrayBuffer}} instance, or any typed array or {{ECMAScript/DataView}}
-            backed by either, will throw a {{ECMAScript/TypeError}} exception.
+            A call to <code>writeInto</code> with a resizable {{ArrayBuffer}} instance, a
+            {{SharedArrayBuffer}} instance, or any typed array or {{DataView}}
+            backed by either, will throw a {{TypeError}} exception.
        </li>
         <li>
-            A call to <code>writeIntoResizable</code> with a {{ECMAScript/SharedArrayBuffer}}
-            instance, or any typed array or {{ECMAScript/DataView}} backed by one, will throw a
-            {{ECMAScript/TypeError}} exception.
+            A call to <code>writeIntoResizable</code> with a {{SharedArrayBuffer}}
+            instance, or any typed array or {{DataView}} backed by one, will throw a
+            {{TypeError}} exception.
         </li>
         <li>
-            A call to <code>writeIntoShared</code> with a resizable {{ECMAScript/ArrayBuffer}}
-            instance, a growable {{ECMAScript/SharedArrayBuffer}} instance, or any typed array or
-            {{ECMAScript/DataView}} backed by one, will throw a {{ECMAScript/TypeError}} exception.
+            A call to <code>writeIntoShared</code> with a resizable {{ArrayBuffer}}
+            instance, a growable {{SharedArrayBuffer}} instance, or any typed array or
+            {{DataView}} backed by one, will throw a {{TypeError}} exception.
         </li>
         <li>
             A call to <code>writeIntoSharedResizable</code> will accept an
-            {{ECMAScript/ArrayBuffer}} instance, a {{ECMAScript/SharedArrayBuffer}} instance, or any
-            typed array or {{ECMAScript/DataView}} backed by either.
+            {{ArrayBuffer}} instance, a {{SharedArrayBuffer}} instance, or any
+            typed array or {{DataView}} backed by either.
         </li>
     </ul>
 </div>
@@ -10976,7 +10908,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     1.  Let |n| be the [=list/size=] of |args|.
     1.  Initialize |argcount| to be min(|maxarg|, |n|).
     1.  Remove from |S| all entries whose type list is not of length |argcount|.
-    1.  If |S| is empty, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If |S| is empty, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Initialize |d| to −1.
     1.  Initialize |method| to <emu-val>undefined</emu-val>.
     1.  If there is more than one entry in |S|, then set
@@ -11171,7 +11103,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
         1.  Otherwise: if there is an entry in |S| that has {{any}} at position |i|
             of its type list, then remove from |S| all other entries.
-        1.  Otherwise: [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  Otherwise: [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |callable| be the [=operation=] or [=extended attribute=]
         of the single entry in |S|.
     1.  If |i| = |d| and |method| is not <emu-val>undefined</emu-val>, then
@@ -11219,7 +11151,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
         overload argument list, then they are ignored.
     *   After ignoring these trailing arguments, only overloads
         that can take this exact number of arguments are considered.
-        If there are none, then a {{ECMAScript/TypeError}} is thrown.
+        If there are none, then a {{TypeError}} is thrown.
 
     Once we have a set of possible overloads with the right number
     of arguments, the ECMAScript values are converted from left to right.
@@ -11240,7 +11172,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     and there is an overload with an <span class=allow-rfc2119>optional</span> argument at this
     position, then
     we will choose that overload.  If there is no valid overload for the type of
-    value passed in here, then we throw a {{ECMAScript/TypeError}}.
+    value passed in here, then we throw a {{TypeError}}.
     Generally, the inspection of the value at the distinguishing argument index does not have any
     side effects, and the only side effects in the overload resolution algorithm are the result of
     converting the ECMAScript values to IDL values.
@@ -11310,7 +11242,7 @@ The characteristics of a legacy factory function are described in [[#legacy-fact
         * the platform object |object|
         * the identifier |name|
         * the type |type|
-    1. If |object| does not [=implement=] |interface|, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1. If |object| does not [=implement=] |interface|, then [=ECMAScript/throw=] a {{TypeError}}.
     1. Return |object|.
 
     Issue: This algo is not yet consistently used everywhere.
@@ -11362,9 +11294,9 @@ default interfaces do not have such steps.
     1.  Let |steps| be |I|'s [=overridden constructor steps=] if they exist, or
         the following steps otherwise:
         1.  If |I| was not declared with a [=constructor operation=],
-            then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+            then [=ECMAScript/throw=] a {{TypeError}}.
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+            [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
         1.  Let |id| be the identifier of interface |I|.
@@ -11433,7 +11365,7 @@ implement the interface on which the
 
     1.  Let |steps| be the following steps:
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+            [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
         1.  [=Compute the effective overload set=] for legacy factory functions with [=identifier=] |id|
@@ -11777,7 +11709,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  Let |esValue| be the <emu-val>this</emu-val> value, if it is not
                     <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
                     [=realm/global object=] otherwise.
-                    (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
+                    (This will subsequently cause a {{TypeError}} in a few steps, if
                     the global object does not implement |target| and [{{LegacyLenientThis}}] is not
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
@@ -11786,7 +11718,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  If |esValue| does not [=implement=] |target|, then:
                     1.  If |attribute| was specified with the [{{LegacyLenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
-                    1.  Otherwise, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+                    1.  Otherwise, [=ECMAScript/throw=] a {{TypeError}}.
                 1.  If |attribute|'s type is an [=observable array type=], then return |esValue|'s
                     [=backing observable array exotic object=] for |attribute|.
                 1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
@@ -11822,7 +11754,7 @@ in which case they are exposed on every object that [=implements=] the interface
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
-        1.  If no arguments were passed, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If no arguments were passed, then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
         1.  Let |idlObject| be null.
@@ -11830,7 +11762,7 @@ in which case they are exposed on every object that [=implements=] the interface
             1.  Let |esValue| be the <emu-val>this</emu-val> value, if it is not
                 <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
                 [=realm/global object=] otherwise.
-                (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
+                (This will subsequently cause a {{TypeError}} in a few steps, if
                 the global object does not implement |target| and [{{LegacyLenientThis}}] is not
                 specified.)
                 <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
@@ -11838,7 +11770,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 |esValue|, |id|, and "setter".
             1.  Let |validThis| be true if |esValue| [=implements=] |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LegacyLenientThis}}]
-                [=extended attribute=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+                [=extended attribute=], then [=ECMAScript/throw=] a {{TypeError}}.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
                 1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|esValue|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
@@ -11848,7 +11780,7 @@ in which case they are exposed on every object that [=implements=] the interface
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
                 1.  Let |Q| be [=?=] <a abstract-op>Get</a>(|esValue|, |id|).
                 1.  If <a abstract-op>Type</a>(|Q|) is not Object, then [=ECMAScript/throw=] a
-                    {{ECMAScript/TypeError}}.
+                    {{TypeError}}.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
                 1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, <emu-val>false</emu-val>).
@@ -11902,7 +11834,7 @@ accessed, they are able to expose instance-specific data.
 Note: Attempting to assign to a property corresponding to a
 [=read only=] [=attribute=]
 results in different behavior depending on whether the script doing so is in strict mode.
-When in strict mode, such an assignment will result in a {{ECMAScript/TypeError}}
+When in strict mode, such an assignment will result in a {{TypeError}}
 being thrown.  When not in strict mode, the assignment attempt will be ignored.
 
 
@@ -11971,14 +11903,14 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  Let |esValue| be the <emu-val>this</emu-val> value, if it is not
                     <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
                     [=realm/global object=] otherwise.
-                    (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
+                    (This will subsequently cause a {{TypeError}} in a few steps, if
                     the global object does not implement |target| and [{{LegacyLenientThis}}] is not
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, |id|, and "method".
                 1.  If |esValue| does not [=implement=] the interface |target|,
-                    [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+                    [=ECMAScript/throw=] a {{TypeError}}.
                 1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
                     to |esValue|.
             1.  Let |n| be the [=list/size=] of |args|.
@@ -12197,7 +12129,7 @@ then there must exist a property with the following characteristics:
             *   the [=identifier=] of the [=stringifier=], and
             *   the type "<code>method</code>".
         1.  If |O| does not [=implement=] the [=interface=]
-            on which the stringifier was declared, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+            on which the stringifier was declared, then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on how <code>stringifier</code> was specified:
             <dl class="switch">
@@ -12243,7 +12175,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>@@iterator</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{ECMAScript/TypeError}}.
+                    {{TypeError}}.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>key+value</code>"
                     as its [=default iterator object/kind=], and [=default iterator object/index=]
@@ -12259,7 +12191,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>keys</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{ECMAScript/TypeError}}.
+                    {{TypeError}}.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>key</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
@@ -12273,7 +12205,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>values</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{ECMAScript/TypeError}}.
+                    {{TypeError}}.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>value</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
@@ -12288,7 +12220,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>forEach</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{ECMAScript/TypeError}}.
+                    {{TypeError}}.
                 1.  Let |idlCallback| be |callback|, [=converted to an IDL value|converted=] to a
                     {{Function}}.
                 1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference
@@ -12394,7 +12326,7 @@ must be {{%IteratorPrototype%}}.
         *   the identifier "<code>next</code>", and
         *   the type "<code>method</code>".
     1.  If |object| is not a [=default iterator object=] for |interface|,
-        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |index| be |object|'s [=default iterator object/index=].
     1.  Let |kind| be |object|'s [=default iterator object/kind=].
     1.  Let |values| be |object|'s [=default iterator object/target=]'s [=value pairs to iterate over=].
@@ -12427,7 +12359,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>@@asyncIterator</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                {{ECMAScript/TypeError}}.
+                {{TypeError}}.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12452,7 +12384,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>keys</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                {{ECMAScript/TypeError}}.
+                {{TypeError}}.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12475,7 +12407,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>values</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                {{ECMAScript/TypeError}}.
+                {{TypeError}}.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12584,7 +12516,7 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
         1.  Return |thisValidationPromiseCapability|.\[[Promise]].
 
     1.  If |object| is not a [=default asynchronous iterator object=] for |interface|, then:
-        1.  Let |error| be a new {{ECMAScript/TypeError}}.
+        1.  Let |error| be a new {{TypeError}}.
         1.  Perform [=!=] [$Call$](|thisValidationPromiseCapability|.\[[Reject]],
             <emu-val>undefined</emu-val>, « |error| »).
         1.  Return |thisValidationPromiseCapability|.\[[Promise]].
@@ -12674,7 +12606,7 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
         1.  Return |returnPromiseCapability|.\[[Promise]].
 
     1.  If |object| is not a [=default asynchronous iterator object=] for |interface|, then:
-        1.  Let |error| be a new {{ECMAScript/TypeError}}.
+        1.  Let |error| be a new {{TypeError}}.
         1.  Perform [=!=] [$Call$](|returnPromiseCapability|.\[[Reject]],
             <emu-val>undefined</emu-val>, « |error| »).
         1.  Return |returnPromiseCapability|.\[[Promise]].
@@ -12865,7 +12797,7 @@ with the following characteristics:
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
-        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |key| → |value| of |map|:
             1. Let |esKey| and |esValue| be |key| and |value| [=converted to an ECMAScript value=].
@@ -13166,7 +13098,7 @@ with the following characteristics:
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
-        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |value| of |set|:
             1. Let |esValue| be |value| [=converted to an ECMAScript value=].
@@ -14157,7 +14089,7 @@ the special value “missing”, which represents a missing optional argument.
         1.  Set |X| to |getResult|.\[[Value]].
         1.  If <a abstract-op>IsCallable</a>(|X|) is <emu-val>false</emu-val>,
             then set |completion| to [=Completion Record=] { \[[Type]]: throw, \[[Value]]: a
-            newly created {{ECMAScript/TypeError}} object, \[[Target]]: empty }, and jump
+            newly created {{TypeError}} object, \[[Target]]: empty }, and jump
             to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |thisArg| to |O| (overriding the provided value).
     1.  Let |esArgs| be the result of [=Web IDL arguments list/converting=] |args| to an ECMAScript
@@ -14210,7 +14142,7 @@ when applied to a [=legacy callback interface object=].
     is <dfn lt="create a legacy callback interface object">created</dfn> as follows:
 
     1.  Let |steps| be the following steps:
-        1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
+        1.  [=ECMAScript/Throw=] a {{TypeError}}.
     1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, 0).
@@ -14284,7 +14216,7 @@ a return type that is a [=promise type=].
     1.  Let |completion| be an uninitialized variable.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
     1.  If <a abstract-op>IsConstructor</a>(|F|) is <emu-val>false</emu-val>, throw a
-        {{ECMAScript/TypeError}} exception.
+        {{TypeError}} exception.
     1.  Let |realm| be |F|'s [=associated realm=].
     1.  Let |relevant settings| be |realm|'s [=realm/settings object=].
     1.  Let |stored settings| be |callable|'s [=callback context=].
@@ -14349,7 +14281,7 @@ In the ECMAScript binding, the [=interface prototype object=] for {{DOMException
 has its \[[Prototype]] [=internal slot=] set to the intrinsic object {{%Error.prototype%}},
 as defined in the [=create an interface prototype object=] abstract operation.
 
-Additionally, if an implementation gives native {{ECMAScript/Error}} objects special powers or
+Additionally, if an implementation gives native {{Error}} objects special powers or
 nonstandard properties (such as a <code>stack</code> property),
 it should also expose those on {{DOMException}} objects.
 
@@ -14950,7 +14882,7 @@ The following typographic conventions are used in this document:
 *   Grammar non-terminals: <emu-nt>ExampleGrammarNonTerminal</emu-t>
 *   Grammar symbols: <emu-t class="regex">identifier</emu-t>
 *   IDL types: {{unsigned long}}
-*   ECMAScript classes: {{ECMAScript/Map}}
+*   ECMAScript classes: {{Map}}
 *   ECMAScript language types: Object
 *   Code snippets: <code>a = b + obj.f()</code>
 *   Scalar values: U+0030 (0)

--- a/index.bs
+++ b/index.bs
@@ -4,7 +4,6 @@ H1: Web IDL
 Shortname: webidl
 Text Macro: TWITTER webidl
 Text Macro: LATESTRD 2022-09
-Text Macro: COMMIT-SHA foo
 Abstract: This standard defines an interface definition language, Web IDL, that can be used to describe interfaces that
 Abstract: are intended to be implemented in web browsers.
 Translation: ja https://triple-underscore.github.io/WebIDL-ja.html

--- a/index.bs
+++ b/index.bs
@@ -7231,10 +7231,10 @@ In effect, where <var ignore>x</var> is a Number value,
     1.  If the conversion is to an IDL type [=extended attribute associated with|associated with=]
         the [{{EnforceRange}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-            then [=ECMAScript/throw=] a {{TypeError}}.
+            then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Set |x| to <a abstract-op>IntegerPart</a>(|x|).
         1.  If |x| &lt; |lowerBound| or |x| &gt; |upperBound|,
-            then [=ECMAScript/throw=] a {{TypeError}}.
+            then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Return |x|.
     1.  If |x| is not <emu-val>NaN</emu-val> and the conversion is to an IDL type
         [=extended attribute associated with|associated with=] the [{{Clamp}}] extended attribute,
@@ -7262,7 +7262,7 @@ In effect, where <var ignore>x</var> is a Number value,
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |S| be the set of finite IEEE 754 single-precision floating
         point values except −0, but with two special values added: 2<sup>128</sup> and
         −2<sup>128</sup>.
@@ -7271,7 +7271,7 @@ In effect, where <var ignore>x</var> is a Number value,
         <em>even significand</em> if there are two [=equally close values=].
         (The two special values 2<sup>128</sup> and −2<sup>128</sup>
         are considered to have even significands for this purpose.)
-    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If |y| is +0 and |x| is negative, return −0.
     1.  Return |y|.
 </div>
@@ -7335,7 +7335,7 @@ value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{double}} value
         that represents the same numeric value as |x|.
 </div>
@@ -7446,7 +7446,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
     1.  Let |x| be [=?=] <a abstract-op>ToString</a>(|V|).
     1.  If the value of any [=ECMAScript String/element=]
-        of |x| is greater than 255, then [=ECMAScript/throw=] a {{TypeError}}.
+        of |x| is greater than 255, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return an IDL {{ByteString}} value
         whose length is the length of |x|, and where the value of each element is
         the value of the corresponding element of |x|.
@@ -7496,7 +7496,7 @@ values are represented by ECMAScript Object values.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{object}} value by running the following algorithm:
 
-    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{object}} value that is a reference to the same object as |V|.
 </div>
 
@@ -7516,7 +7516,7 @@ IDL {{symbol}} values are represented by ECMAScript Symbol values.
     An ECMAScript value |V| is [=converted to an IDL value|converted=] to an IDL {{symbol}} value
     by running the following algorithm:
 
-    1.  If <a abstract-op>Type</a>(|V|) is not Symbol, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If <a abstract-op>Type</a>(|V|) is not Symbol, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{symbol}} value that is a reference to the same symbol as |V|.
 </div>
 
@@ -7538,7 +7538,7 @@ values are represented by ECMAScript Object values (including [=function objects
     to an IDL [=interface type=] value by running the following algorithm (where |I| is the [=interface=]):
 
     1.  If |V| [=implements=] |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
-    1.  [=ECMAScript/Throw=] a {{TypeError}}.
+    1.  [=ECMAScript/Throw=] a <l spec=ecmascript>{{TypeError}}</l>.
 </div>
 
 <p id="interface-to-es">
@@ -7560,7 +7560,7 @@ values are represented by ECMAScript Object values (including [=function objects
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=callback interface type=] value by running the following algorithm:
 
-    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL [=callback interface type=] value that represents a reference to |V|, with
         the <a spec="HTML">incumbent settings object</a> as the [=callback context=].
 </div>
@@ -7586,7 +7586,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
     to an IDL [=dictionary type=] value by
     running the following algorithm (where |D| is the [=dictionary type=]):
 
-    1.  If <a abstract-op>Type</a>(|esDict|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If <a abstract-op>Type</a>(|esDict|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |idlDict| be an empty [=ordered map=], representing a dictionary of type |D|.
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|'s [=inherited dictionaries=],
         in order from least to most derived.
@@ -7651,7 +7651,7 @@ values.
 
     1.  Let |S| be the result of calling [=?=] <a abstract-op>ToString</a>(|V|).
     1.  If |S| is not one of |E|'s [=enumeration values=],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the enumeration value of type |E| that is equal to |S|.
 </div>
 
@@ -7681,7 +7681,7 @@ IDL [=callback function types=] are represented by ECMAScript [=function objects
         whose type is a [=nullable type|nullable=]
         [=callback function=]
         that is annotated with [{{LegacyTreatNonObjectAsNull}}],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL [=callback function type=] value
         that represents a reference to the same object that |V| represents, with the
         <a spec="HTML">incumbent settings object</a> as the [=callback context=].
@@ -7752,10 +7752,10 @@ ECMAScript Array values.
     to an IDL <a lt="sequence type">sequence&lt;<var ignore>T</var>&gt;</a> value as follows:
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
     1.  If |method| is <emu-val>undefined</emu-val>,
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]
         from |V| and |method|.
 </div>
@@ -7895,7 +7895,7 @@ ECMAScript Object values.
     to an IDL <code>[=record=]&lt;|K|, |V|></code> value as follows:
 
     1.  If <a abstract-op>Type</a>(|O|) is not Object,
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |result| be a new empty instance of <code>[=record=]&lt;|K|, |V|></code>.
     1.  Let |keys| be [=?=] |O|.\[[OwnPropertyKeys]]().
     1.  [=list/For each=] |key| of |keys|:
@@ -8487,7 +8487,7 @@ that correspond to the union's [=member types=].
     1.  If |types| includes {{bigint}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{bigint}}.
-    1.  [=ECMAScript/Throw=] a {{TypeError}}.
+    1.  [=ECMAScript/Throw=] a <l spec=ecmascript>{{TypeError}}</l>.
 </div>
 
 <p id="union-to-es">
@@ -8537,15 +8537,15 @@ are represented by objects of the corresponding ECMAScript class, with the follo
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have an \[[ArrayBufferData]] [=/internal slot=],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and <a abstract-op>IsSharedArrayBuffer</a>(|V|) is true, then [=ECMAScript/throw=]
-        a {{TypeError}}.
+        a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
         [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|) is true,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{ArrayBuffer}} value that is a reference
         to the same object as |V|.
 </div>
@@ -8557,15 +8557,15 @@ are represented by objects of the corresponding ECMAScript class, with the follo
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have a \[[DataView]] [=/internal slot=],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and <a abstract-op>IsSharedArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
         [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{DataView}} value that is a reference
         to the same object as |V|.
 </div>
@@ -8591,15 +8591,15 @@ are represented by objects of the corresponding ECMAScript class, with the follo
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have a \[[TypedArrayName]] [=/internal slot=]
         with a value equal to |T|'s name,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and <a abstract-op>IsSharedArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
         [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1.  Return the IDL value of type |T| that is a reference to the same object as |V|.
 </div>
 
@@ -10817,7 +10817,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     1.  Let |n| be the [=list/size=] of |args|.
     1.  Initialize |argcount| to be min(|maxarg|, |n|).
     1.  Remove from |S| all entries whose type list is not of length |argcount|.
-    1.  If |S| is empty, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If |S| is empty, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1.  Initialize |d| to −1.
     1.  Initialize |method| to <emu-val>undefined</emu-val>.
     1.  If there is more than one entry in |S|, then set
@@ -11012,7 +11012,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
         1.  Otherwise: if there is an entry in |S| that has {{any}} at position |i|
             of its type list, then remove from |S| all other entries.
-        1.  Otherwise: [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Otherwise: [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1.  Let |callable| be the [=operation=] or [=extended attribute=]
         of the single entry in |S|.
     1.  If |i| = |d| and |method| is not <emu-val>undefined</emu-val>, then
@@ -11151,7 +11151,7 @@ The characteristics of a legacy factory function are described in [[#legacy-fact
         * the platform object |object|
         * the identifier |name|
         * the type |type|
-    1. If |object| does not [=implement=] |interface|, then [=ECMAScript/throw=] a {{TypeError}}.
+    1. If |object| does not [=implement=] |interface|, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1. Return |object|.
 
     Issue: This algo is not yet consistently used everywhere.
@@ -11203,9 +11203,9 @@ default interfaces do not have such steps.
     1.  Let |steps| be |I|'s [=overridden constructor steps=] if they exist, or
         the following steps otherwise:
         1.  If |I| was not declared with a [=constructor operation=],
-            then [=ECMAScript/throw=] a {{TypeError}}.
+            then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{TypeError}}.
+            [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
         1.  Let |id| be the identifier of interface |I|.
@@ -11274,7 +11274,7 @@ implement the interface on which the
 
     1.  Let |steps| be the following steps:
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{TypeError}}.
+            [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
         1.  [=Compute the effective overload set=] for legacy factory functions with [=identifier=] |id|
@@ -11627,7 +11627,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  If |esValue| does not [=implement=] |target|, then:
                     1.  If |attribute| was specified with the [{{LegacyLenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
-                    1.  Otherwise, [=ECMAScript/throw=] a {{TypeError}}.
+                    1.  Otherwise, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
                 1.  If |attribute|'s type is an [=observable array type=], then return |esValue|'s
                     [=backing observable array exotic object=] for |attribute|.
                 1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
@@ -11663,7 +11663,7 @@ in which case they are exposed on every object that [=implements=] the interface
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
-        1.  If no arguments were passed, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If no arguments were passed, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
         1.  Let |idlObject| be null.
@@ -11679,7 +11679,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 |esValue|, |id|, and "setter".
             1.  Let |validThis| be true if |esValue| [=implements=] |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LegacyLenientThis}}]
-                [=extended attribute=], then [=ECMAScript/throw=] a {{TypeError}}.
+                [=extended attribute=], then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
                 1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|esValue|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
@@ -11689,7 +11689,7 @@ in which case they are exposed on every object that [=implements=] the interface
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
                 1.  Let |Q| be [=?=] <a abstract-op>Get</a>(|esValue|, |id|).
                 1.  If <a abstract-op>Type</a>(|Q|) is not Object, then [=ECMAScript/throw=] a
-                    {{TypeError}}.
+                    <l spec=ecmascript>{{TypeError}}</l>}.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
                 1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, <emu-val>false</emu-val>).
@@ -11819,7 +11819,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, |id|, and "method".
                 1.  If |esValue| does not [=implement=] the interface |target|,
-                    [=ECMAScript/throw=] a {{TypeError}}.
+                    [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
                 1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
                     to |esValue|.
             1.  Let |n| be the [=list/size=] of |args|.
@@ -12038,7 +12038,7 @@ then there must exist a property with the following characteristics:
             *   the [=identifier=] of the [=stringifier=], and
             *   the type "<code>method</code>".
         1.  If |O| does not [=implement=] the [=interface=]
-            on which the stringifier was declared, then [=ECMAScript/throw=] a {{TypeError}}.
+            on which the stringifier was declared, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on how <code>stringifier</code> was specified:
             <dl class="switch">
@@ -12084,7 +12084,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>@@iterator</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{TypeError}}.
+                    <l spec=ecmascript>{{TypeError}}</l>}.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>key+value</code>"
                     as its [=default iterator object/kind=], and [=default iterator object/index=]
@@ -12100,7 +12100,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>keys</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{TypeError}}.
+                    <l spec=ecmascript>{{TypeError}}</l>}.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>key</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
@@ -12114,7 +12114,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>values</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{TypeError}}.
+                    <l spec=ecmascript>{{TypeError}}</l>}.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>value</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
@@ -12129,7 +12129,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>forEach</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    {{TypeError}}.
+                    <l spec=ecmascript>{{TypeError}}</l>}.
                 1.  Let |idlCallback| be |callback|, [=converted to an IDL value|converted=] to a
                     {{Function}}.
                 1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference
@@ -12235,7 +12235,7 @@ must be {{%IteratorPrototype%}}.
         *   the identifier "<code>next</code>", and
         *   the type "<code>method</code>".
     1.  If |object| is not a [=default iterator object=] for |interface|,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1.  Let |index| be |object|'s [=default iterator object/index=].
     1.  Let |kind| be |object|'s [=default iterator object/kind=].
     1.  Let |values| be |object|'s [=default iterator object/target=]'s [=value pairs to iterate over=].
@@ -12268,7 +12268,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>@@asyncIterator</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                {{TypeError}}.
+                <l spec=ecmascript>{{TypeError}}</l>}.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12293,7 +12293,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>keys</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                {{TypeError}}.
+                <l spec=ecmascript>{{TypeError}}</l>}.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12316,7 +12316,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>values</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                {{TypeError}}.
+                <l spec=ecmascript>{{TypeError}}</l>}.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12425,7 +12425,7 @@ The \[[Prototype]] [=/internal slot=] of an [=asynchronous iterator prototype ob
         1.  Return |thisValidationPromiseCapability|.\[[Promise]].
 
     1.  If |object| is not a [=default asynchronous iterator object=] for |interface|, then:
-        1.  Let |error| be a new {{TypeError}}.
+        1.  Let |error| be a new <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Perform [=!=] [$Call$](|thisValidationPromiseCapability|.\[[Reject]],
             <emu-val>undefined</emu-val>, « |error| »).
         1.  Return |thisValidationPromiseCapability|.\[[Promise]].
@@ -12515,7 +12515,7 @@ The \[[Prototype]] [=/internal slot=] of an [=asynchronous iterator prototype ob
         1.  Return |returnPromiseCapability|.\[[Promise]].
 
     1.  If |object| is not a [=default asynchronous iterator object=] for |interface|, then:
-        1.  Let |error| be a new {{TypeError}}.
+        1.  Let |error| be a new <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Perform [=!=] [$Call$](|returnPromiseCapability|.\[[Reject]],
             <emu-val>undefined</emu-val>, « |error| »).
         1.  Return |returnPromiseCapability|.\[[Promise]].
@@ -12706,7 +12706,7 @@ with the following characteristics:
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
-        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |key| → |value| of |map|:
             1. Let |esKey| and |esValue| be |key| and |value| [=converted to an ECMAScript value=].
@@ -13007,7 +13007,7 @@ with the following characteristics:
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
-        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
         1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |value| of |set|:
             1. Let |esValue| be |value| [=converted to an ECMAScript value=].
@@ -13998,7 +13998,7 @@ the special value “missing”, which represents a missing optional argument.
         1.  Set |X| to |getResult|.\[[Value]].
         1.  If <a abstract-op>IsCallable</a>(|X|) is <emu-val>false</emu-val>,
             then set |completion| to [=Completion Record=] { \[[Type]]: throw, \[[Value]]: a
-            newly created {{TypeError}} object, \[[Target]]: empty }, and jump
+            newly created <l spec=ecmascript>{{TypeError}}</l>} object, \[[Target]]: empty }, and jump
             to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |thisArg| to |O| (overriding the provided value).
     1.  Let |esArgs| be the result of [=Web IDL arguments list/converting=] |args| to an ECMAScript
@@ -14051,7 +14051,7 @@ when applied to a [=legacy callback interface object=].
     is <dfn lt="create a legacy callback interface object">created</dfn> as follows:
 
     1.  Let |steps| be the following steps:
-        1.  [=ECMAScript/Throw=] a {{TypeError}}.
+        1.  [=ECMAScript/Throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
     1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, 0).
@@ -14125,7 +14125,7 @@ a return type that is a [=promise type=].
     1.  Let |completion| be an uninitialized variable.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
     1.  If <a abstract-op>IsConstructor</a>(|F|) is <emu-val>false</emu-val>, throw a
-        {{TypeError}} exception.
+        <l spec=ecmascript>{{TypeError}}</l>} exception.
     1.  Let |realm| be |F|'s [=associated realm=].
     1.  Let |relevant settings| be |realm|'s [=realm/settings object=].
     1.  Let |stored settings| be |callable|'s [=callback context=].


### PR DESCRIPTION
This is purely an editorial change. It fixes the link errors the current spec has (around Memory and Memory/buffer), and additionally removes a large number of the explicit anchors defined in the spec. For the most part these removals were simple; in a few places I fixed the linking syntax down in the spec body as well.

The abstract-op anchors left behind just aren't being detected by WebRef; [I opened an issue about them](https://github.com/w3c/webref/issues/888). When that's fixed we should be able to remove that entire block.

A number of the remaining anchors are things that should probably be fixed in ECMAScript, but I don't have bandwidth to do that right now. I haven't done a full accounting of the remaining anchor values; some of them might also be removable right now.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1270.html" title="Last updated on Feb 28, 2023, 7:56 PM UTC (4f171d4)">Preview</a> | <a href="https://whatpr.org/webidl/1270/8728881...4f171d4.html" title="Last updated on Feb 28, 2023, 7:56 PM UTC (4f171d4)">Diff</a>