### PR TITLE
Allow static operations with the same names as default operations in Maplike/Setlike/Iterable/AsyncIterable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3936,12 +3936,10 @@ the iterator objects returned by <code class="idl">entries</code>,
 <code class="idl">keys</code>, <code class="idl">values</code>, and {{@@iterator}} are
 actual [=array iterator objects=].
 
-Interfaces with iterable declarations must not
-have any [=interface members=]
-named "<code>entries</code>", "<code>forEach</code>",
-"<code>keys</code>", or "<code>values</code>",
-or have any [=inherited interfaces=]
-that have [=members=] with these names.
+[=Interfaces=] with an [=iterable declaration=] must not have any [=attributes=], [=constants=], or
+[=regular operations=] named "<code>entries</code>", "<code>forEach</code>", "<code>keys</code>", or
+"<code>values</code>", or have any [=inherited interfaces=] that have [=attributes=], [=constants=],
+or [=regular operations=] with these names.
 
 <div class="example" id="example-d2254660">
 
@@ -4124,9 +4122,10 @@ The prose may also define <dfn export>asynchronous iterator initialization steps
 receive the instance of the [=interface=] being iterated, the newly-created iterator object, and a
 [=list=] of IDL values representing the arguments passed, if any.
 
-[=Interfaces=] with an [=asynchronously iterable declaration=] must not have any
-[=interface members=] named "<code>entries</code>", "<code>keys</code>", or "<code>values</code>",
-or have any [=inherited interfaces=] that have [=interface members=] with these names.
+[=Interfaces=] with an [=asynchronously iterable declaration=] must not have any [=attributes=],
+[=constants=], or [=regular operations=] named "<code>entries</code>", "<code>keys</code>", or
+"<code>values</code>", or have any [=inherited interfaces=] that have [=attributes=], [=constants=],
+or [=regular operations=] with these names.
 
 <div class="example" id="example-69bd6dcd">
 
@@ -4282,14 +4281,11 @@ keyword is used, this includes <code class="idl">entries</code>,
 For read–write maplikes, it also includes <code class="idl">clear</code>,
 <code class="idl">delete</code>, and <code class="idl">set</code> methods.
 
-Maplike interfaces must not
-have any [=interface members=]
-named "<code>entries</code>", "<code>forEach</code>",
-"<code>get</code>", "<code>has</code>",
-"<code>keys</code>", "<code>size</code>", or
-"<code>values</code>",
-or have any [=inherited interfaces=]
-that have [=members=] with these names.
+Maplike interfaces must not have any [=attributes=], [=constants=], or [=regular operations=] named
+"<code>entries</code>", "<code>forEach</code>", "<code>get</code>", "<code>has</code>",
+"<code>keys</code>", "<code>size</code>", or "<code>values</code>", or have any
+[=inherited interfaces=] that have [=attributes=], [=constants=], or [=regular operations=] with
+these names.
 
 Read–write maplike interfaces must not
 have any [=attributes=]
@@ -4298,12 +4294,11 @@ or [=constants=] named
 or "<code>set</code>", or have any [=inherited interfaces=]
 that have [=attributes=] or [=constants=] with these names.
 
-Note: Read-write maplike interfaces <em>can</em> have <em>operations</em>
-named "<code>clear</code>", "<code>delete</code>", or "<code>set</code>",
-which will override the default implementation of those methods
-(defined in [[#es-maplike]]). If such operations are defined, they must
-match the input and output expectations of each method, defined in their
-default implementation sections.
+Note: Read-write maplike interfaces <em>can</em> have <em>regular operations</em> named
+"<code>clear</code>", "<code>delete</code>", or "<code>set</code>", which will override the default
+implementation of those methods (defined in [[#es-maplike]]). If such regular operations are
+defined, they must match the input and output expectations of each method, defined in their default
+implementation sections.
 
 An interface must not have more than one
 [=maplike declaration=].
@@ -4376,13 +4371,11 @@ keyword is used, this includes <code class="idl">entries</code>,
 For read–write setlikes, it also includes <code class="idl">add</code>,
 <code class="idl">clear</code>, and <code class="idl">delete</code> methods.
 
-Setlike interfaces must not
-have any [=interface members=]
-named "<code>entries</code>", "<code>forEach</code>",
-"<code>has</code>", "<code>keys</code>",
-"<code>size</code>", or "<code>values</code>",
-or have any [=inherited interfaces=]
-that have [=members=] with these names.
+Setlike interfaces must not have any [=attributes=], [=constants=], or [=regular operations=] named
+"<code>entries</code>", "<code>forEach</code>", "<code>has</code>", "<code>keys</code>",
+"<code>size</code>", or "<code>values</code>", or have any [=inherited interfaces=] that have
+[=attributes=], [=constants=], or [=regular operations=] with these names.
+
 Read–write setlike interfaces must not
 have any [=attributes=]
 or [=constants=] named
@@ -4390,10 +4383,11 @@ or [=constants=] named
 or "<code>delete</code>", or have any [=inherited interfaces=]
 that have [=attributes=] or [=constants=] with these names.
 
-Note: Read-write setlike interfaces <em>can</em> have <em>operations</em>
-named "<code>add</code>", "<code>clear</code>", or "<code>delete</code>",
-which will override the default implementation of those methods
-(defined in [[#es-setlike]].)
+Note: Read-write setlike interfaces <em>can</em> have <em>regular operations</em> named
+"<code>add</code>", "<code>clear</code>", or "<code>delete</code>", which will override the default
+implementation of those methods (defined in [[#es-setlike]]). If such regular operations are
+defined, they must match the input and output expectations of each method, defined in their default
+implementation sections.
 
 An interface must not have more than one
 [=setlike declaration=].

--- a/index.bs
+++ b/index.bs
@@ -7439,7 +7439,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     to an IDL {{ByteString}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ToString</a>(|V|).
-    1.  If the value of any [=ECMAScript String/element=]
+    1.  If the value of any <l spec=ecmascript>[=ECMAScript String/element=]</l>
         of |x| is greater than 255, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return an IDL {{ByteString}} value
         whose length is the length of |x|, and where the value of each element is
@@ -7451,8 +7451,8 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     an IDL {{ByteString}} value to an ECMAScript
     value is a String
     value whose length is the length of the {{ByteString}},
-    and the value of each [=ECMAScript String/element=] of which is the value of the corresponding element
-    of the {{ByteString}}.
+    and the value of each <l spec=ecmascript>[=ECMAScript String/element=]</l> of which is the value
+    of the corresponding element of the {{ByteString}}.
 </p>
 
 

--- a/index.bs
+++ b/index.bs
@@ -16,6 +16,7 @@ spec: ecmascript; type: dfn;
     for: ECMAScript;
         text: constructor
         text: realm
+spec: dom; type: dfn; text: element
 </pre>
 
 <pre class="anchors">


### PR DESCRIPTION
close #1280.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1281.html" title="Last updated on Mar 16, 2023, 9:28 PM UTC (5c207b4)">Preview</a> | <a href="https://whatpr.org/webidl/1281/8813044...5c207b4.html" title="Last updated on Mar 16, 2023, 9:28 PM UTC (5c207b4)">Diff</a>