### PR TITLE
Clarify #named-properties-object

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11430,6 +11430,12 @@ for that interface on which named properties are exposed.
     1.  Return |obj|.
 </div>
 
+Note: The \[[OwnPropertyKeys]] internal method of a named properties object
+continues to use <a abstract-op>OrdinaryOwnPropertyKeys</a>,
+unlike the counterpart for [=legacy platform objects=].
+Since named properties are not “real” own properties,
+they will not be returned by this internal method.
+
 The [=class string=] of a [=named properties object=]
 is the concatenation of the [=interface=]'s
 [=identifier=] and the string "<code>Properties</code>".


### PR DESCRIPTION
This patch clarifies [#named-properties-object](https://webidl.spec.whatwg.org/#named-properties-object) per whatwg/html#9068 by adding a note that reads

> The [[OwnPropertyKeys]] internal method of a named properties object continues to use [OrdinaryOwnPropertyKeys](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryownpropertykeys), unlike the counterpart for [legacy platform objects](https://webidl.spec.whatwg.org/#dfn-legacy-platform-object). Since named properties are not “real” own properties, they will not be returned by this internal method.

The use of “real” in scare quotes is based on the wording in [#es-legacy-platform-objects](https://webidl.spec.whatwg.org/#es-legacy-platform-objects), but I’m open to suggestions for a more precise wording if needed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1285.html" title="Last updated on Mar 28, 2023, 11:31 AM UTC (2463456)">Preview</a> | <a href="https://whatpr.org/webidl/1285/98d9cc4...2463456.html" title="Last updated on Mar 28, 2023, 11:31 AM UTC (2463456)">Diff</a>