### PR TITLE
Editorial: Define the WebIDL string types in terms of Infra types.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5846,7 +5846,7 @@ The {{USVString}} type
 corresponds to [=scalar value strings=].
 Depending on the context,
 these can be treated as sequences of either 16-bit unsigned integer [=code units=]
-or [=scalar value=] [=code points=].
+or [=scalar values=].
 
 There is no way to represent a constant {{USVString}}
 value in IDL, although {{USVString}} [=dictionary member=] [=dictionary member/default values=]

--- a/index.bs
+++ b/index.bs
@@ -2099,15 +2099,14 @@ the value is the IDL {{undefined}} value.
              :  {{DOMString}}
              :  an [=enumeration=] type
              :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
-                is the sequence of 16 bit unsigned integer [=code units=]
-                corresponding to the UTF-16 encoding of |S|.
+                is |S|.
              :  {{ByteString}}
-             :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
-                is the sequence of 8 bit unsigned integer code units
-                corresponding to the UTF-8 encoding of |S|.
+             :: Assert: |S| doesn't contain any [=code points=] higher than U+00FF.
+
+                The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
+                is the [=isomorphic encoding=] of |S|.
              :  {{USVString}}
-             :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
-                is the [=scalar value string=] whose [=code points=] are |S|.
+             :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token is |S|.
         </dl>
 </div>
 
@@ -5795,9 +5794,6 @@ The {{bigint}} type is an arbitrary integer type, unrestricted in range.
 <h4 oldids="dom-DOMString" id="idl-DOMString" interface>DOMString</h4>
 
 The {{DOMString}} type corresponds to [=strings=].
-The sequence of unsigned 16-bit integers in a [=string=]
-is commonly interpreted as a UTF-16 encoded string [[!RFC2781]]
-although this is not required.
 
 Note: Note also that <emu-val>null</emu-val>
 is not a value of type {{DOMString}}.
@@ -7475,10 +7471,8 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 <div id="USVString-to-es" algorithm="convert an USVString to an ECMAScript value">
 
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{USVString}} value to an ECMAScript
-    value is the String
-    value that represents the sequence of [=code units=]
-    in the IDL {{USVString}}.
+    an IDL {{USVString}} value |S| to an ECMAScript
+    value is |S|.
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -11,7 +11,9 @@ Complain About: accidental-2119 no
 </pre>
 
 <pre class="link-defaults">
-spec: infra; type: dfn; text: list
+spec: infra; type: dfn;
+    text: code unit
+    text: list
 spec: ecmascript; type: dfn;
     for: ECMAScript;
         text: constructor

--- a/index.bs
+++ b/index.bs
@@ -2097,6 +2097,7 @@ the value is the IDL {{undefined}} value.
     1.  Depending on the type of the argument:
         <dl class="switch">
              :  {{DOMString}}
+             :  {{USVString}}
              :  an [=enumeration=] type
              :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
                 is |S|.
@@ -2105,8 +2106,6 @@ the value is the IDL {{undefined}} value.
 
                 The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
                 is the [=isomorphic encoding=] of |S|.
-             :  {{USVString}}
-             :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token is |S|.
         </dl>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2097,15 +2097,15 @@ the value is the IDL {{undefined}} value.
              :  {{DOMString}}
              :  an [=enumeration=] type
              :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
-                is the sequence of 16 bit unsigned integer code units
-                (hereafter referred to just as <dfn id="dfn-code-unit">code units</dfn>)
+                is the sequence of 16 bit unsigned integer [=code units=]
                 corresponding to the UTF-16 encoding of |S|.
              :  {{ByteString}}
              :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
                 is the sequence of 8 bit unsigned integer code units
                 corresponding to the UTF-8 encoding of |S|.
              :  {{USVString}}
-             :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token is |S|.
+             :: The value of the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
+                is the [=scalar value string=] whose [=code points=] are |S|.
         </dl>
 </div>
 
@@ -5436,7 +5436,8 @@ allows authors to register callbacks by providing objects that implement the
 
 <h3 id="idl-types">Types</h3>
 
-This section lists the types supported by Web IDL, the set of values
+This section lists the types supported by Web IDL,
+the set of values or [[Infra|Infra]] type
 corresponding to each type, and how [=constants=]
 of that type are represented.
 
@@ -5791,9 +5792,9 @@ The {{bigint}} type is an arbitrary integer type, unrestricted in range.
 
 <h4 oldids="dom-DOMString" id="idl-DOMString" interface>DOMString</h4>
 
-The {{DOMString}} type corresponds to
-the set of all possible sequences of [=code units=].
-Such sequences are commonly interpreted as UTF-16 encoded strings [[!RFC2781]]
+The {{DOMString}} type corresponds to [=strings=].
+The sequence of unsigned 16-bit integers in a [=string=]
+is commonly interpreted as a UTF-16 encoded string [[!RFC2781]]
 although this is not required.
 
 Note: Note also that <emu-val>null</emu-val>
@@ -5818,7 +5819,7 @@ can be set to [=value of string literal tokens|the value=] of a
 <h4 oldids="dom-ByteString" id="idl-ByteString" interface>ByteString</h4>
 
 The {{ByteString}} type
-corresponds to the set of all possible sequences of bytes.
+corresponds to [=byte sequences=].
 Such sequences might be interpreted as UTF-8 encoded strings [[!RFC3629]]
 or strings in some other 8-bit-per-code-unit encoding, although this is not required.
 
@@ -5845,10 +5846,10 @@ can be set to [=value of string literal tokens|the value=] of a
 <h4 oldids="dom-USVString" id="idl-USVString" interface>USVString</h4>
 
 The {{USVString}} type
-corresponds to the set of all possible sequences of
-[=scalar values=],
-which are all of the Unicode code points apart from the
-surrogate code points.
+corresponds to [=scalar value strings=].
+Depending on the context,
+these can be treated as sequences of either 16-bit unsigned integer [=code units=]
+or [=scalar value=] [=code points=].
 
 There is no way to represent a constant {{USVString}}
 value in IDL, although {{USVString}} [=dictionary member=] [=dictionary member/default values=]
@@ -7471,12 +7472,11 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
 <div id="USVString-to-es" algorithm="convert an USVString to an ECMAScript value">
 
-    An IDL {{USVString}} value is [=converted to an ECMAScript value|converted=]
-    to an ECMAScript value by running the following algorithm:
-
-    1.  Let |scalarValues| be the sequence of [=scalar values=] the {{USVString}} represents.
-    1.  Let |string| be the sequence of [=code units=] that results from encoding |scalarValues| in UTF-16.
-    1.  Return the String value that represents the same sequence of [=code units=] as |string|.
+    The result of [=converted to an ECMAScript value|converting=]
+    an IDL {{USVString}} value to an ECMAScript
+    value is the String
+    value that represents the sequence of [=code units=]
+    in the IDL {{USVString}}.
 </div>
 
 


### PR DESCRIPTION
This might be sufficient for #335, but I think it's useful for spec authors to go roughly this far even if there's more to do to completely fix that issue. 

cc/ @domfarolino 

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1287.html" title="Last updated on Apr 21, 2023, 3:33 PM UTC (5690199)">Preview</a> | <a href="https://whatpr.org/webidl/1287/a35410d...5690199.html" title="Last updated on Apr 21, 2023, 3:33 PM UTC (5690199)">Diff</a>