### PR TITLE
Editorial: Fix typo in the overload resolution algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10797,7 +10797,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     1.  Let |n| be the [=list/size=] of |args|.
     1.  Initialize |argcount| to be min(|maxarg|, |n|).
     1.  Remove from |S| all entries whose type list is not of length |argcount|.
-    1.  If |S| is empty, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+    1.  If |S| is empty, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Initialize |d| to −1.
     1.  Initialize |method| to <emu-val>undefined</emu-val>.
     1.  If there is more than one entry in |S|, then set


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1299.html" title="Last updated on Apr 28, 2023, 8:27 AM UTC (db6050a)">Preview</a> | <a href="https://whatpr.org/webidl/1299/29ea31b...db6050a.html" title="Last updated on Apr 28, 2023, 8:27 AM UTC (db6050a)">Diff</a>