### PR TITLE
Editorial: Handle exceptions thrown while converting 'invoke's return value.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14186,7 +14186,8 @@ the special value “missing”, which represents a missing optional argument.
         |callResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
         |callResult|.\[[Value]] to an IDL value of the same type as the operation's
-        return type.
+        return type. If this throws an exception, set |completion| to the completion value
+        representing the thrown exception.
     1.  <i id="call-user-object-operation-return">Return:</i> at this
         point |completion| will be set to an IDL value or an [=abrupt completion=].
         1.  [=Clean up after running a callback=] with |stored settings|.

--- a/index.bs
+++ b/index.bs
@@ -14275,7 +14275,8 @@ described in the previous section).
         |callResult| and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
         |callResult|.\[[Value]] to an IDL value of the same type as the operation's
-        return type.
+        return type. If this throws an exception, set |completion| to the completion value
+        representing the thrown exception.
     1.  <i id="invoke-return">Return:</i> at this
         point |completion| will be set to an IDL value or an [=abrupt completion=].
         1.  [=Clean up after running a callback=] with |stored settings|.
@@ -14317,7 +14318,8 @@ a return type that is a [=promise type=].
         |callResult| and jump to the step labeled <a href="#construct-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
         |callResult|.\[[Value]] to an IDL value of the same type as the operation's
-        return type.
+        return type. If this throws an exception, set |completion| to the completion value
+        representing the thrown exception.
     1.  <i id="construct-return">Return:</i> at this
         point |completion| will be set to an IDL value or an [=abrupt completion=].
         1.  [=Clean up after running a callback=] with |stored settings|.

--- a/index.bs
+++ b/index.bs
@@ -14274,7 +14274,7 @@ described in the previous section).
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
-        |callResult|.\[[Value]] to an IDL value of the same type as the operation's
+        |callResult|.\[[Value]] to an IDL value of the same type as |callable|'s
         return type. If this throws an exception, set |completion| to the completion value
         representing the thrown exception.
     1.  <i id="invoke-return">Return:</i> at this
@@ -14317,7 +14317,7 @@ a return type that is a [=promise type=].
     1.  If |callResult| is an [=abrupt completion=], set |completion| to
         |callResult| and jump to the step labeled <a href="#construct-return"><i>return</i></a>.
     1.  Set |completion| to the result of [=converted to an IDL value|converting=]
-        |callResult|.\[[Value]] to an IDL value of the same type as the operation's
+        |callResult|.\[[Value]] to an IDL value of the same type as |callable|'s
         return type. If this throws an exception, set |completion| to the completion value
         representing the thrown exception.
     1.  <i id="construct-return">Return:</i> at this


### PR DESCRIPTION
Without this, the exception skips the "clean up" steps, which seems bad. I expect everyone's already implemented this correctly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1323.html" title="Last updated on Jun 21, 2023, 7:18 PM UTC (13f6a82)">Preview</a> | <a href="https://whatpr.org/webidl/1323/95f57dd...13f6a82.html" title="Last updated on Jun 21, 2023, 7:18 PM UTC (13f6a82)">Diff</a>