### PR TITLE
Make call and invoke either return an IDL value or throw.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14188,12 +14188,12 @@ the special value “missing”, which represents a missing optional argument.
         |callResult|.\[[Value]] to an IDL value of the same type as the operation's
         return type.
     1.  <i id="call-user-object-operation-return">Return:</i> at this
-        point |completion| will be set to an ECMAScript completion value.
+        point |completion| will be set to an IDL value or an [=abrupt completion=].
         1.  [=Clean up after running a callback=] with |stored settings|.
         1.  [=Clean up after running script=] with |relevant settings|.
-        1.  If |completion| is a normal completion, return |completion|.
+        1.  If |completion| is an IDL value, return |completion|.
         1.  If |completion| is an [=abrupt completion=] and the operation has a [=return type=]
-            that is <em>not</em> a [=promise type=], return |completion|.
+            that is <em>not</em> a [=promise type=], throw |completion|.\[[Value]].
         1.  Let |rejectedPromise| be [=!=] <a abstract-op>Call</a>({{%Promise.reject%}},
             {{%Promise%}}, «|completion|.\[[Value]]»).
         1.  Return the result of [=converted to an IDL value|converting=]
@@ -14276,12 +14276,12 @@ described in the previous section).
         |callResult|.\[[Value]] to an IDL value of the same type as the operation's
         return type.
     1.  <i id="invoke-return">Return:</i> at this
-        point |completion| will be set to an ECMAScript completion value.
+        point |completion| will be set to an IDL value or an [=abrupt completion=].
         1.  [=Clean up after running a callback=] with |stored settings|.
         1.  [=Clean up after running script=] with |relevant settings|.
-        1.  If |completion| is a normal completion, return |completion|.
+        1.  If |completion| is an IDL value, return |completion|.
         1.  If |completion| is an [=abrupt completion=] and the callback function has a
-            [=return type=] that is <em>not</em> a [=promise type=], return |completion|.
+            [=return type=] that is <em>not</em> a [=promise type=], throw |completion|.\[[Value]].
         1.  Let |rejectedPromise| be [=!=] <a abstract-op>Call</a>({{%Promise.reject%}},
             {{%Promise%}}, «|completion|.\[[Value]]»).
         1.  Return the result of [=converted to an IDL value|converting=]

--- a/index.bs
+++ b/index.bs
@@ -14318,9 +14318,10 @@ a return type that is a [=promise type=].
         |callResult|.\[[Value]] to an IDL value of the same type as the operation's
         return type.
     1.  <i id="construct-return">Return:</i> at this
-        point |completion| will be set to an ECMAScript completion value.
+        point |completion| will be set to an IDL value or an [=abrupt completion=].
         1.  [=Clean up after running a callback=] with |stored settings|.
         1.  [=Clean up after running script=] with |relevant settings|.
+        1.  If |completion| is an [=abrupt completion=], throw |completion|.\[[Value]].
         1.  Return |completion|.
 </div>
 


### PR DESCRIPTION
They used to return JS Completions, contrary to the claim at their definitions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1324.html" title="Last updated on Jun 20, 2023, 9:08 PM UTC (5d50915)">Preview</a> | <a href="https://whatpr.org/webidl/1324/c45a0f3...5d50915.html" title="Last updated on Jun 20, 2023, 9:08 PM UTC (5d50915)">Diff</a>