### PR TITLE
Meta: update build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "private": true,
   "description": "Checks that the WebIDL grammar is LL(1) and performs postprocessing",
   "devDependencies": {
-    "jsdom": "^20.0.0",
-    "syntax-cli": "0.0.97",
-    "webidl-grammar-post-processor": "^1.0.0"
+    "jsdom": "^22.1.0",
+    "syntax-cli": "0.1.27",
+    "webidl-grammar-post-processor": "^1.0.1"
   },
   "scripts": {
     "webidl-grammar-post-processor": "webidl-grammar-post-processor"


### PR DESCRIPTION
Inspired by #1329, but does not actually fix the warnings.

I manually verified that nothing changes in the output.