### PR TITLE
Remove extra }'s from some TypeError references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8737,15 +8737,15 @@ class, with the following additional restrictions on those objects.
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         or |V| does not have a \[[TypedArrayName]] [=/internal slot=]
         with a value equal to |T|'s name,
-        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and <a abstract-op>IsSharedArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
         [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL value of type |T| that is a reference to the same object as |V|.
 </div>
 
@@ -11183,7 +11183,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
         1.  Otherwise: if there is an entry in |S| that has {{any}} at position |i|
             of its type list, then remove from |S| all other entries.
-        1.  Otherwise: [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        1.  Otherwise: [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |callable| be the [=operation=] or [=extended attribute=]
         of the single entry in |S|.
     1.  If |i| = |d| and |method| is not <emu-val>undefined</emu-val>, then
@@ -11322,7 +11322,7 @@ The characteristics of a legacy factory function are described in [[#legacy-fact
         * the platform object |object|
         * the identifier |name|
         * the type |type|
-    1. If |object| does not [=implement=] |interface|, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+    1. If |object| does not [=implement=] |interface|, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1. Return |object|.
 
     Issue: This algo is not yet consistently used everywhere.
@@ -11374,9 +11374,9 @@ default interfaces do not have such steps.
     1.  Let |steps| be |I|'s [=overridden constructor steps=] if they exist, or
         the following steps otherwise:
         1.  If |I| was not declared with a [=constructor operation=],
-            then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+            then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+            [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
         1.  Let |id| be the identifier of interface |I|.
@@ -11444,7 +11444,7 @@ implement the interface on which the
 
     1.  Let |steps| be the following steps:
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+            [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
         1.  [=Compute the effective overload set=] for legacy factory functions with [=identifier=] |id|
@@ -11803,7 +11803,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  If |esValue| does not [=implement=] |target|, then:
                     1.  If |attribute| was specified with the [{{LegacyLenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
-                    1.  Otherwise, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+                    1.  Otherwise, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
                 1.  If |attribute|'s type is an [=observable array type=], then return |esValue|'s
                     [=backing observable array exotic object=] for |attribute|.
                 1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
@@ -11839,7 +11839,7 @@ in which case they are exposed on every object that [=implements=] the interface
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
-        1.  If no arguments were passed, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        1.  If no arguments were passed, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
         1.  Let |idlObject| be null.
@@ -11855,7 +11855,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 |esValue|, |id|, and "setter".
             1.  Let |validThis| be true if |esValue| [=implements=] |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LegacyLenientThis}}]
-                [=extended attribute=], then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+                [=extended attribute=], then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
                 1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|esValue|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
@@ -11865,7 +11865,7 @@ in which case they are exposed on every object that [=implements=] the interface
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
                 1.  Let |Q| be [=?=] <a abstract-op>Get</a>(|esValue|, |id|).
                 1.  If <a abstract-op>Type</a>(|Q|) is not Object, then [=ECMAScript/throw=] a
-                    <l spec=ecmascript>{{TypeError}}</l>}.
+                    <l spec=ecmascript>{{TypeError}}</l>.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
                 1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, <emu-val>false</emu-val>).
@@ -11995,7 +11995,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, |id|, and "method".
                 1.  If |esValue| does not [=implement=] the interface |target|,
-                    [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+                    [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
                 1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
                     to |esValue|.
             1.  Let |n| be the [=list/size=] of |args|.
@@ -12214,7 +12214,7 @@ then there must exist a property with the following characteristics:
             *   the [=identifier=] of the [=stringifier=], and
             *   the type "<code>method</code>".
         1.  If |O| does not [=implement=] the [=interface=]
-            on which the stringifier was declared, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+            on which the stringifier was declared, then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on how <code>stringifier</code> was specified:
             <dl class="switch">
@@ -12260,7 +12260,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>@@iterator</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    <l spec=ecmascript>{{TypeError}}</l>}.
+                    <l spec=ecmascript>{{TypeError}}</l>.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>key+value</code>"
                     as its [=default iterator object/kind=], and [=default iterator object/index=]
@@ -12276,7 +12276,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>keys</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    <l spec=ecmascript>{{TypeError}}</l>}.
+                    <l spec=ecmascript>{{TypeError}}</l>.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>key</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
@@ -12290,7 +12290,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>values</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    <l spec=ecmascript>{{TypeError}}</l>}.
+                    <l spec=ecmascript>{{TypeError}}</l>.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
                     |esValue| as its [=default iterator object/target=], "<code>value</code>" as its
                     [=default iterator object/kind=], and [=default iterator object/index=] set to 0.
@@ -12305,7 +12305,7 @@ then there must exist a property with the following characteristics:
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, "<code>forEach</code>", and "<code>method</code>".
                 1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                    <l spec=ecmascript>{{TypeError}}</l>}.
+                    <l spec=ecmascript>{{TypeError}}</l>.
                 1.  Let |idlCallback| be |callback|, [=converted to an IDL value|converted=] to a
                     {{Function}}.
                 1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference
@@ -12411,7 +12411,7 @@ must be {{%IteratorPrototype%}}.
         *   the identifier "<code>next</code>", and
         *   the type "<code>method</code>".
     1.  If |object| is not a [=default iterator object=] for |interface|,
-        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |index| be |object|'s [=default iterator object/index=].
     1.  Let |kind| be |object|'s [=default iterator object/kind=].
     1.  Let |values| be |object|'s [=default iterator object/target=]'s [=value pairs to iterate over=].
@@ -12444,7 +12444,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>@@asyncIterator</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                <l spec=ecmascript>{{TypeError}}</l>}.
+                <l spec=ecmascript>{{TypeError}}</l>.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12469,7 +12469,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>keys</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                <l spec=ecmascript>{{TypeError}}</l>}.
+                <l spec=ecmascript>{{TypeError}}</l>.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12492,7 +12492,7 @@ and the string "<code> Iterator</code>".
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, "<code>values</code>", and "<code>method</code>".
             1.  If |esValue| does not [=implement=] |definition|, then [=ECMAScript/throw=] a
-                <l spec=ecmascript>{{TypeError}}</l>}.
+                <l spec=ecmascript>{{TypeError}}</l>.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
                 |esValue|.
             1.  Let |idlArgs| be the result of
@@ -12601,7 +12601,7 @@ The \[[Prototype]] [=/internal slot=] of an [=asynchronous iterator prototype ob
         1.  Return |thisValidationPromiseCapability|.\[[Promise]].
 
     1.  If |object| is not a [=default asynchronous iterator object=] for |interface|, then:
-        1.  Let |error| be a new <l spec=ecmascript>{{TypeError}}</l>}.
+        1.  Let |error| be a new <l spec=ecmascript>{{TypeError}}</l>.
         1.  Perform [=!=] [$Call$](|thisValidationPromiseCapability|.\[[Reject]],
             <emu-val>undefined</emu-val>, « |error| »).
         1.  Return |thisValidationPromiseCapability|.\[[Promise]].
@@ -12691,7 +12691,7 @@ The \[[Prototype]] [=/internal slot=] of an [=asynchronous iterator prototype ob
         1.  Return |returnPromiseCapability|.\[[Promise]].
 
     1.  If |object| is not a [=default asynchronous iterator object=] for |interface|, then:
-        1.  Let |error| be a new <l spec=ecmascript>{{TypeError}}</l>}.
+        1.  Let |error| be a new <l spec=ecmascript>{{TypeError}}</l>.
         1.  Perform [=!=] [$Call$](|returnPromiseCapability|.\[[Reject]],
             <emu-val>undefined</emu-val>, « |error| »).
         1.  Return |returnPromiseCapability|.\[[Promise]].
@@ -12882,7 +12882,7 @@ with the following characteristics:
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
-        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |key| → |value| of |map|:
             1. Let |esKey| and |esValue| be |key| and |value| [=converted to an ECMAScript value=].
@@ -13183,7 +13183,7 @@ with the following characteristics:
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
-        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
         1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |value| of |set|:
             1. Let |esValue| be |value| [=converted to an ECMAScript value=].
@@ -14174,7 +14174,7 @@ the special value “missing”, which represents a missing optional argument.
         1.  Set |X| to |getResult|.\[[Value]].
         1.  If <a abstract-op>IsCallable</a>(|X|) is <emu-val>false</emu-val>,
             then set |completion| to [=Completion Record=] { \[[Type]]: throw, \[[Value]]: a
-            newly created <l spec=ecmascript>{{TypeError}}</l>} object, \[[Target]]: empty }, and jump
+            newly created <l spec=ecmascript>{{TypeError}}</l> object, \[[Target]]: empty }, and jump
             to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
         1.  Set |thisArg| to |O| (overriding the provided value).
     1.  Let |esArgs| be the result of [=Web IDL arguments list/converting=] |args| to an ECMAScript
@@ -14228,7 +14228,7 @@ when applied to a [=legacy callback interface object=].
     is <dfn lt="create a legacy callback interface object">created</dfn> as follows:
 
     1.  Let |steps| be the following steps:
-        1.  [=ECMAScript/Throw=] a <l spec=ecmascript>{{TypeError}}</l>}.
+        1.  [=ECMAScript/Throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |F| be <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  Perform <a abstract-op>SetFunctionLength</a>(|F|, 0).
@@ -14303,7 +14303,7 @@ a return type that is a [=promise type=].
     1.  Let |completion| be an uninitialized variable.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
     1.  If <a abstract-op>IsConstructor</a>(|F|) is <emu-val>false</emu-val>, throw a
-        <l spec=ecmascript>{{TypeError}}</l>} exception.
+        <l spec=ecmascript>{{TypeError}}</l> exception.
     1.  Let |realm| be |F|'s [=associated realm=].
     1.  Let |relevant settings| be |realm|'s [=realm/settings object=].
     1.  Let |stored settings| be |callable|'s [=callback context=].


### PR DESCRIPTION
PR #1270's substitutions ended up turning some occurrences of

    {{ECMAScript/TypeError}}

into

    <l spec=ecmascript>{{TypeError}}</l>}

which a trailing "}" character at the end.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1351.html" title="Last updated on Aug 14, 2023, 2:03 PM UTC (1139bc2)">Preview</a> | <a href="https://whatpr.org/webidl/1351/c2ca1a4...1139bc2.html" title="Last updated on Aug 14, 2023, 2:03 PM UTC (1139bc2)">Diff</a>