### PR TITLE
Throw TypeError if `[Replaceable]` setter fails to reconfigure the property

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11857,7 +11857,7 @@ in which case they are exposed on every object that [=implements=] the interface
             1.  If |validThis| is false and |attribute| was not specified with the [{{LegacyLenientThis}}]
                 [=extended attribute=], then [=ECMAScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
-                1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|esValue|, |id|, |V|).
+                1.  Perform [=?=] <a abstract-op>CreateDataPropertyOrThrow</a>(|esValue|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
             1.  If |validThis| is false, then return <emu-val>undefined</emu-val>.
             1.  If |attribute| is declared with a [{{LegacyLenientSetter}}] extended attribute, then


### PR DESCRIPTION
This change aligns the spec with WebKit and Gecko, favouring throwing an error rather than failing silently, which is more idiomatic (all ECMA-262 built-ins are strict mode code).

WebIDL spec attempts to throw a TypeError whenever permitted by web reality, like for [invalid `this` value](https://webidl.spec.whatwg.org/#ref-for-LegacyLenientThis%E2%91%A8). This change is a step towards that direction.

See also: https://github.com/whatwg/html/pull/9722.

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Implemented in WebKit since https://github.com/WebKit/WebKit/commit/1e336abec35481176bd436ef85e1e19bfd24057b.
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/41902
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1480949

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1360.html" title="Last updated on Sep 11, 2023, 8:22 AM UTC (f36ac71)">Preview</a> | <a href="https://whatpr.org/webidl/1360/bc4a416...f36ac71.html" title="Last updated on Sep 11, 2023, 8:22 AM UTC (f36ac71)">Diff</a>