### PR TITLE
Editorial: Remove the note on `@@unscopables` and `[Global]` interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11510,10 +11510,6 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
     1.  Otherwise, set |interfaceProtoObj| to [$OrdinaryObjectCreate$](|proto|).
     1.  If |interface| has any [=member=] declared with the [{{Unscopable}}] [=extended attribute=],
         then:
-
-        Issue: Should an {{@@unscopables}} property also be defined if |interface| is
-        declared with the [{{Global}}] [=extended attribute=]?
-        This is discussed in <a href="https://github.com/whatwg/webidl/issues/544">issue #544</a>.
         1.  Let |unscopableObject| be [$OrdinaryObjectCreate$](<emu-val>null</emu-val>).
         1.  [=list/For each=] [=exposed=] [=member=] |member| of |interface|
             that is declared with the [{{Unscopable}}] [=extended attribute=]:


### PR DESCRIPTION
Per https://github.com/whatwg/webidl/issues/544#issuecomment-1649826889: I can't come up with a good reasoning to add an exception for `[Global]` interfaces, even tho the code like `with (window) { ... }` probably doesn't exist in the wild.

_cc_ @bathos


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1361.html" title="Last updated on Sep 10, 2023, 9:06 PM UTC (f819707)">Preview</a> | <a href="https://whatpr.org/webidl/1361/bc4a416...f819707.html" title="Last updated on Sep 10, 2023, 9:06 PM UTC (f819707)">Diff</a>