### PR TITLE
Fix rotated column headers on Distinguishable table

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -180,7 +180,7 @@ urlPrefix: https://tc39.es/proposal-resizablearraybuffer/; spec: RESIZABLE-BUFFE
 
         /* Firefox needs the extra DIV for some reason, otherwise the text disappears if you rotate */
         #distinguishable-table tr:first-child th div {
-          transform: translate(26px, 31px) rotate(315deg);
+          transform: translate(27px, 64px) rotate(315deg);
           width: 30px;
         }
 


### PR DESCRIPTION
At some point the transform that rotated the #distinguishable-table column headers stopped matching up; I'm not sure why. The `translate()` just needed a little shifting to get them back into alignment.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1380.html" title="Last updated on Dec 19, 2023, 11:54 PM UTC (5630491)">Preview</a> | <a href="https://whatpr.org/webidl/1380/10e559d...5630491.html" title="Last updated on Dec 19, 2023, 11:54 PM UTC (5630491)">Diff</a>