### PR TITLE
Replace CreateMethodProperty with DefineMethodProperty

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12328,8 +12328,8 @@ then there must exist a property with the following characteristics:
     of [=interface=] |definition| on |target|, given [=realm=] |realm|, run the following steps:
 
     1.  If |definition| has an [=indexed property getter=], then:
-        1.  Perform [$CreateMethodProperty$](|target|, {{@@iterator}},
-            {{%Array.prototype.values%}}).
+        1.  Perform [$DefineMethodProperty$](|target|, {{@@iterator}},
+            {{%Array.prototype.values%}}, false).
         1.  If |definition| has a [=value iterator=], then:
             1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>entries</code>",
                 {{%Array.prototype.entries%}}).
@@ -12354,7 +12354,7 @@ then there must exist a property with the following characteristics:
             1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
             1.  Perform [$SetFunctionName$](|F|, "<code>entries</code>").
             1.  Perform [$SetFunctionLength$](|F|, 0).
-            1.  Perform [$CreateMethodProperty$](|target|, {{@@iterator}}, |F|).
+            1.  Perform [$DefineMethodProperty$](|target|, {{@@iterator}}, |F|, false).
             1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>entries</code>", |F|).
         1.  Define the <code class="idl">keys</code> method:
             1.  Let |steps| be the following series of steps:
@@ -12546,7 +12546,7 @@ and the string "<code> Iterator</code>".
         1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
         1.  Perform [$SetFunctionName$](|F|, "<code>entries</code>").
         1.  Perform [$SetFunctionLength$](|F|, 0).
-        1.  Perform [$CreateMethodProperty$](|target|, {{@@asyncIterator}}, |F|).
+        1.  Perform [$DefineMethodProperty$](|target|, {{@@asyncIterator}}, |F|, false).
         1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>entries</code>", |F|).
     1.  If |definition| has a [=pair asynchronously iterable declaration=], then define the
         <code class="idl">keys</code> method:
@@ -12596,7 +12596,7 @@ and the string "<code> Iterator</code>".
         1.  Perform [$SetFunctionLength$](|F|, 0).
         1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>values</code>", |F|).
         1.  If |definition| has a [=value asynchronously iterable declaration=], then perform [=!=]
-            [$CreateMethodProperty$](|target|, {{@@asyncIterator}}, |F|).
+            [$DefineMethodProperty$](|target|, {{@@asyncIterator}}, |F|, false).
 </div>
 
 <div algorithm>
@@ -13508,12 +13508,12 @@ the realm given as an argument.
             1.  Let |id| be |interface|'s [=identifier=].
             1.  Let |interfaceObject| be the result of [=create an interface object|creating
                 an interface object=] for |interface| with |id| in |realm|.
-            1.  Perform [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
+            1.  Perform [$DefineMethodProperty$](|target|, |id|, |interfaceObject|, false).
             1.  If the |interface| is declared with a [{{LegacyWindowAlias}}] [=extended attribute=],
                 and |target| implements the {{Window}} [=interface=], then:
                 1.  [=list/iterate|For every=] [=LegacyWindowAlias identifier|identifier=] |id| in
                     [{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifier|identifiers=]:
-                    1.  Perform [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
+                    1.  Perform [$DefineMethodProperty$](|target|, |id|, |interfaceObject|, false).
         1.  If the |interface| is declared with a [{{LegacyFactoryFunction}}] [=extended attribute=],
             then:
             1.  [=list/iterate|For every=] [=LegacyFactoryFunction identifier|identifier=] |id| in
@@ -13521,18 +13521,18 @@ the realm given as an argument.
                 1.  Let |legacyFactoryFunction| be the result of
                     [=create a legacy factory function|creating a legacy factory function=] with
                     |id| for |interface| in |realm|.
-                1.  Perform [$CreateMethodProperty$](|target|, |id|, |legacyFactoryFunction|).
+                1.  Perform [$DefineMethodProperty$](|target|, |id|, |legacyFactoryFunction|, false).
     1.  [=list/iterate|For every=] [=callback interface=] |interface| that is [=exposed=] in
         |realm| and on which [=constants=] are defined:
         1.  Let |id| be |interface|'s [=identifier=].
         1.  Let |interfaceObject| be the result of [=create a legacy callback interface
             object|creating a legacy callback interface object=] for |interface| with |id| in |realm|.
-        1.  Perform [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
+        1.  Perform [$DefineMethodProperty$](|target|, |id|, |interfaceObject|, false).
     1.  [=list/iterate|For every=] [=namespace=] |namespace| that is [=exposed=] in
         |realm|:
         1.  Let |id| be |namespace|'s [=identifier=].
         1.  Let |namespaceObject| be the result of [=create a namespace object|creating a namespace object=] for |namespace| in |realm|.
-        1.  Perform [$CreateMethodProperty$](|target|, |id|, |namespaceObject|).
+        1.  Perform [$DefineMethodProperty$](|target|, |id|, |namespaceObject|, false).
 </div>
 
 <div class="note">
@@ -14443,7 +14443,7 @@ The characteristics of a namespace object are described in [[#namespace-object]]
         1.  Let |id| be |interface|'s [=identifier=].
         1.  Let |interfaceObject| be the result of [=create an interface object|creating an
             interface object=] for |interface| with |id| in |realm|.
-        1.  Perform [$CreateMethodProperty$](|namespaceObject|, |id|, |interfaceObject|).
+        1.  Perform [$DefineMethodProperty$](|namespaceObject|, |id|, |interfaceObject|, false).
     1.  Return |namespaceObject|.
 </div>
 


### PR DESCRIPTION
Fixes #1389

There's still 4 "review drafts" from 2023 that refer to CreateMethodProperty, but I assume those shouldn't be updated?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1391.html" title="Last updated on Mar 11, 2024, 6:08 PM UTC (53f0feb)">Preview</a> | <a href="https://whatpr.org/webidl/1391/400ce04...53f0feb.html" title="Last updated on Mar 11, 2024, 6:08 PM UTC (53f0feb)">Diff</a>