### PR TITLE
Export "an exception was thrown"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14589,7 +14589,8 @@ must propagate to the caller, and if
 not caught there, to its caller, and so on.
 
 Per [[#conventions]], an algorithm specified in this document may intercept thrown exceptions, either by specifying
-the exact steps to take if <dfn>an exception was thrown</dfn>, or by explicitly handling [=abrupt completions=].
+the exact steps to take if <dfn export>an exception was thrown</dfn>, or by explicitly handling
+[=abrupt completions=].
 
 <div class="example" id="example-17059fd2">
 


### PR DESCRIPTION
This is useful in other specifications, which have to manually bring in the un-exported definition: https://github.com/WICG/shared-storage/pull/131/files#diff-6f5a1d8263b0b0c42e2716ba5750e3652e359532647ac934c1c70086ae3ceddaR23-R24. It seems useful to allow other specifications to hook into this though.

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
