### PR TITLE
Add Float16Array

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -74,6 +74,16 @@ urlPrefix: https://tc39.es/proposal-resizablearraybuffer/; spec: RESIZABLE-BUFFE
         text: IsResizableArrayBuffer; url: sec-isresizablearraybuffer
 </pre>
 
+<pre class=biblio>
+{
+    "PROPOSAL-FLOAT16ARRAY": {
+        "publisher": "Ecma",
+        "href": "https://tc39.es/proposal-float16array/",
+        "title": "Proposal to add float16 TypedArrays to JavaScript"
+    }
+}
+</pre>
+
 <style>
         pre.set {
           font-size: 80%;
@@ -6488,7 +6498,7 @@ data. The table below lists these types and the kind of buffer or view they repr
         <td>A view on to a [=buffer type=] instance that exposes it as an array of unsigned 8-bit integers with clamped conversions
     <tr>
         <td><dfn id="idl-Float16Array" interface>Float16Array</dfn>
-        <td rowspan=3>A view on to a [=buffer type=] instance that exposes it as an array of IEEE 754 floating point numbers of the given size in bits; Float16Array corresponds to the ECMAScript proposal <a href="https://github.com/tc39/proposal-float16array">proposal-float16array</a>
+        <td rowspan=3>A view on to a [=buffer type=] instance that exposes it as an array of IEEE 754 floating point numbers of the given size in bits; Float16Array corresponds to the ECMAScript proposal [[PROPOSAL-FLOAT16ARRAY]].
     <tr>
         <td><dfn id="idl-Float32Array" interface>Float32Array</dfn>
     <tr>

--- a/index.bs
+++ b/index.bs
@@ -6488,7 +6488,7 @@ data. The table below lists these types and the kind of buffer or view they repr
         <td>A view on to a [=buffer type=] instance that exposes it as an array of unsigned 8-bit integers with clamped conversions
     <tr>
         <td><dfn id="idl-Float16Array" interface>Float16Array</dfn>
-        <td rowspan=2>A view on to a [=buffer type=] instance that exposes it as an array of IEEE 754 floating point numbers of the given size in bits
+        <td rowspan=3>A view on to a [=buffer type=] instance that exposes it as an array of IEEE 754 floating point numbers of the given size in bits
     <tr>
         <td><dfn id="idl-Float32Array" interface>Float32Array</dfn>
     <tr>

--- a/index.bs
+++ b/index.bs
@@ -6488,7 +6488,7 @@ data. The table below lists these types and the kind of buffer or view they repr
         <td>A view on to a [=buffer type=] instance that exposes it as an array of unsigned 8-bit integers with clamped conversions
     <tr>
         <td><dfn id="idl-Float16Array" interface>Float16Array</dfn>
-        <td rowspan=3>A view on to a [=buffer type=] instance that exposes it as an array of IEEE 754 floating point numbers of the given size in bits
+        <td rowspan=3>A view on to a [=buffer type=] instance that exposes it as an array of IEEE 754 floating point numbers of the given size in bits; Float16Array corresponds to the ECMAScript proposal <a href="https://github.com/tc39/proposal-float16array">proposal-float16array</a>
     <tr>
         <td><dfn id="idl-Float32Array" interface>Float32Array</dfn>
     <tr>

--- a/index.bs
+++ b/index.bs
@@ -5597,6 +5597,7 @@ The <dfn id="dfn-typed-array-type" export>typed array types</dfn> are
 {{Uint8ClampedArray}},
 {{BigInt64Array}},
 {{BigUint64Array}},
+{{Float16Array}},
 {{Float32Array}}, and
 {{Float64Array}}.
 
@@ -6486,8 +6487,10 @@ data. The table below lists these types and the kind of buffer or view they repr
         <td><dfn id="idl-Uint8ClampedArray" interface>Uint8ClampedArray</dfn>
         <td>A view on to a [=buffer type=] instance that exposes it as an array of unsigned 8-bit integers with clamped conversions
     <tr>
-        <td><dfn id="idl-Float32Array" interface>Float32Array</dfn>
+        <td><dfn id="idl-Float16Array" interface>Float16Array</dfn>
         <td rowspan=2>A view on to a [=buffer type=] instance that exposes it as an array of IEEE 754 floating point numbers of the given size in bits
+    <tr>
+        <td><dfn id="idl-Float32Array" interface>Float32Array</dfn>
     <tr>
         <td><dfn id="idl-Float64Array" interface>Float64Array</dfn>
 </table>
@@ -6514,6 +6517,7 @@ in [[#js-buffer-source-types]].
         "Uint8ClampedArray"
         "BigInt64Array"
         "BigUint64Array"
+        "Float16Array"
         "Float32Array"
         "Float64Array"
 </pre>
@@ -8807,7 +8811,8 @@ class, with the following additional restrictions on those objects.
     {{Uint8ClampedArray}},
     {{BigInt64Array}},
     {{BigUint64Array}},
-    {{Float32Array}} or
+    {{Float16Array}},
+    {{Float32Array}}, or
     {{Float64Array}} value
     by running the following algorithm:
 
@@ -14666,7 +14671,7 @@ must support.
     typedef (Int8Array or Int16Array or Int32Array or
              Uint8Array or Uint16Array or Uint32Array or Uint8ClampedArray or
              BigInt64Array or BigUint64Array or
-             Float32Array or Float64Array or DataView) ArrayBufferView;
+             Float16Array or Float32Array or Float64Array or DataView) ArrayBufferView;
 </pre>
 
 The {{ArrayBufferView}} typedef is used to represent


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

The [Float16Array](https://github.com/tc39/proposal-float16array) proposal for JavaScript adds a new TypedArray type holding IEEE binary16 floats. This PR adds it to all of the lists of TypedArray types in WebIDL.

Implementations of the proposal are underway in at least [Chrome](https://bugs.chromium.org/p/v8/issues/detail?id=14012) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1833646), though it'll be some time before they're shippable. I don't know what the appropriate time to merge this is but I figured I should at least open it.

This is a JS feature, but adding it to ArrayBufferView has implications for any API which takes a generic TypedArray, which is quite a few of them. Does that imply they all need new tests? Hopefully not?

Fixes https://github.com/whatwg/webidl/issues/1310.

- [x] At least two implementers are interested (and none opposed):
   * Chromium (implementing JS feature)
   * Gecko (implementing JS feature)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/45483
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A, already implementing
   * Gecko: N/A, already implementing
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=257022
   * Deno: https://github.com/denoland/deno/issues/23277
   * Node.js: https://github.com/nodejs/node/issues/52416
   * webidl2.js: https://github.com/w3c/webidl2.js/pull/777
   * widlparser: https://github.com/plinss/widlparser/pull/86
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: Seems safe to assume this will happen.
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1398.html" title="Last updated on Apr 8, 2024, 8:18 AM UTC (5bde0d3)">Preview</a> | <a href="https://whatpr.org/webidl/1398/402a886...5bde0d3.html" title="Last updated on Apr 8, 2024, 8:18 AM UTC (5bde0d3)">Diff</a>