### PR TITLE
Record timing info for promise resolve/reject and callback

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8244,6 +8244,8 @@ IDL [=promise type=] values are represented by JavaScript [=PromiseCapability=] 
     To <dfn export>resolve</dfn> a <code><a interface>Promise</a>&lt;|T|&gt;</code> |p| with |x| (a
     value of type |T|), perform the following steps:
 
+    1.  [=Record timing info for promise resolver=] given |p| and
+        "<code data-x="">resolve-promise</code>".
     1.  If |x| is not given, then let it be the {{undefined}} value.
     1.  Let |value| be the result of [=converted to a JavaScript value|converting=] |x| to a
         JavaScript value.
@@ -8256,6 +8258,9 @@ IDL [=promise type=] values are represented by JavaScript [=PromiseCapability=] 
 
     To <dfn export>reject</dfn> a <code><a interface>Promise</a>&lt;<var ignore>T</var>&gt;</code>
     |p| with reason |r| (a JavaScript value), perform the following steps:
+
+    1.  [=Record timing info for promise resolver=] given |p| and
+        "<code data-x="">reject-promise</code>".
 
     1.  Perform [=!=] [$Call$](|p|.\[[Reject]], <emu-val>undefined</emu-val>, « |r| »).
 </div>
@@ -14367,6 +14372,7 @@ described in the previous section).
     1.  Let |realm| be |F|'s [=associated realm=].
     1.  Let |relevant settings| be |realm|'s [=realm/settings object=].
     1.  Let |stored settings| be |callable|'s [=callback context=].
+    1.  [=Record timing info for user callback=] with |F| and |relevant settings|.
     1.  [=Prepare to run script=] with |relevant settings|.
     1.  [=Prepare to run a callback=] with |stored settings|.
     1.  Let |jsArgs| be the result of [=Web IDL arguments list/converting=] |args| to a JavaScript


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium (implemented)
   * Gecko (https://github.com/mozilla/standards-positions/issues/929)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Multiple tests in https://wpt.fyi/results/long-animation-frame/tentative?label=experimental&label=master&aligned test this.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: already implemented
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1348405
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=270913
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message]