### PR TITLE
Update 'Creating a sequence from an iterable' to use new iterator AOs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7984,20 +7984,19 @@ JavaScript Array values.
     given an iterable |iterable| and an iterator getter |method|,
     perform the following steps:
 
-    1.  Let |iter| be [=?=] <a abstract-op>GetIterator</a>(|iterable|, <emu-const>sync</emu-const>, |method|).
+    1.  Let |iteratorRecord| be [=?=] <a abstract-op>GetIteratorFromMethod</a>(|iterable|, |method|).
     1.  Initialize |i| to be 0.
     1.  Repeat
-        1.  Let |next| be [=?=] <a abstract-op>IteratorStep</a>(|iter|).
-        1.  If |next| is <emu-val>false</emu-val>,
+        1.  Let |next| be [=?=] <a abstract-op>IteratorStepValue</a>(|iteratorRecord|).
+        1.  If |next| is <emu-const>done</emu-const>,
             then return an IDL sequence value of type
             <a lt="sequence type">sequence&lt;|T|&gt;</a>
             of length |i|, where the value of the element
             at index |j| is
             |S|<sub>|j|</sub>.
-        1.  Let |nextItem| be [=?=] <a abstract-op>IteratorValue</a>(|next|).
         1.  Initialize |S|<sub>|i|</sub> to the result of
             [=converted to an IDL value|converting=]
-            |nextItem| to an IDL value of type |T|.
+            |next| to an IDL value of type |T|.
         1.  Set |i| to |i| + 1.
 </div>
 


### PR DESCRIPTION
`GetIterator` no longer exists in this form (it tries to obtain the method when passed `sync` or `async`), and `IteratorStep`/`IteratorValue` have been merged into a single AO for convenience.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1409.html" title="Last updated on Jun 8, 2024, 2:00 AM UTC (80aef16)">Preview</a> | <a href="https://whatpr.org/webidl/1409/ca9d63d...80aef16.html" title="Last updated on Jun 8, 2024, 2:00 AM UTC (80aef16)">Diff</a>