### PR TITLE
Update `@@foo` symbol notation to `%Symbol.foo%` notation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3896,7 +3896,7 @@ support being iterated over to obtain a sequence of values.
 
 Note: In the JavaScript language binding, an interface that is iterable
 will have <code class="idl">entries</code>, <code class="idl">forEach</code>,
-<code class="idl">keys</code>, <code class="idl">values</code>, and {{@@iterator}}
+<code class="idl">keys</code>, <code class="idl">values</code>, and {{%Symbol.iterator%}}
 properties on its [=interface prototype object=].
 
 If a single type parameter is given, then the interface has a
@@ -3956,7 +3956,7 @@ Prose accompanying an [=interface=] with a [=pair iterator=] must define a [=/li
 Note: This is how [=array iterator objects=] work.
 For interfaces that [=support indexed properties=],
 the iterator objects returned by <code class="idl">entries</code>,
-<code class="idl">keys</code>, <code class="idl">values</code>, and {{@@iterator}} are
+<code class="idl">keys</code>, <code class="idl">values</code>, and {{%Symbol.iterator%}} are
 actual [=array iterator objects=].
 
 [=Interfaces=] with an [=iterable declaration=] must not have any [=attributes=], [=constants=], or
@@ -4002,7 +4002,7 @@ or [=regular operations=] with these names.
     next value to be iterated over.  It has <code>keys</code> and <code>entries</code>
     methods that iterate over the usernames of session objects
     and username/<code class=idl>Session</code> object pairs, respectively.  It also has
-    a {{@@iterator}} method that allows a <code class="idl">SessionManager</code>
+    a {{%Symbol.iterator%}} method that allows a <code class="idl">SessionManager</code>
     to be used in a <code>for..of</code> loop that has the same value as the
     <code>entries</code> method:
 
@@ -4099,7 +4099,7 @@ If given, an [=asynchronously iterable declaration=]'s arguments (matching
 
 <div class="note">
     In the JavaScript language binding, an interface that is asynchronously iterable will have
-    {{@@asyncIterator}} and <code class="idl">values</code> properties on its
+    {{%Symbol.asyncIterator%}} and <code class="idl">values</code> properties on its
     [=interface prototype object=]. If the interface has a
     [=pair asynchronously iterable declaration=], it will additionally have
     <code class="idl">entries</code> and <code class="idl">keys</code> properties. All of these
@@ -4110,7 +4110,7 @@ If given, an [=asynchronously iterable declaration=]'s arguments (matching
     With this in mind, the requirement that all arguments be optional ensures that, in the
     JavaScript binding, <code>for</code>-<code>await</code>-<code>of</code> can work directly on
     instances of the interface, since <code>for</code>-<code>await</code>-<code>of</code> calls the
-    {{@@asyncIterator}} method with no arguments.
+    {{%Symbol.asyncIterator%}} method with no arguments.
 </div>
 
 Prose accompanying an [=interface=] with an [=asynchronously iterable declaration=] must define a
@@ -4213,7 +4213,7 @@ or [=regular operations=] with these names.
     <code>next</code> method that returns the next value to be iterated over.
     It has <code>keys</code> and <code>entries</code> methods that iterate over the usernames of
     session objects and (username, <code class=idl>Session</code>) object pairs, respectively.
-    It also has a {{@@asyncIterator}} method that allows a <code class="idl">SessionManager</code>
+    It also has a {{%Symbol.asyncIterator%}} method that allows a <code class="idl">SessionManager</code>
     to be used in a <code>for await..of</code> loop that has the same value as the
     <code>entries</code> method:
 
@@ -4299,7 +4299,7 @@ with the map entries is similar to that available on JavaScript
 keyword is used, this includes <code class="idl">entries</code>,
 <code class="idl">forEach</code>, <code class="idl">get</code>,
 <code class="idl">has</code>, <code class="idl">keys</code>,
-<code class="idl">values</code>, {{@@iterator}} methods, and a
+<code class="idl">values</code>, {{%Symbol.iterator%}} methods, and a
 <code class="idl">size</code> getter.
 For read–write maplikes, it also includes <code class="idl">clear</code>,
 <code class="idl">delete</code>, and <code class="idl">set</code> methods.
@@ -4390,7 +4390,7 @@ with the set entries is similar to that available on JavaScript
 keyword is used, this includes <code class="idl">entries</code>,
 <code class="idl">forEach</code>, <code class="idl">has</code>,
 <code class="idl">keys</code>, <code class="idl">values</code>,
-{{@@iterator}} methods, and a <code class="idl">size</code> getter.
+{{%Symbol.iterator%}} methods, and a <code class="idl">size</code> getter.
 For read–write setlikes, it also includes <code class="idl">add</code>,
 <code class="idl">clear</code>, and <code class="idl">delete</code> methods.
 
@@ -6987,7 +6987,7 @@ Some objects described in this section are defined to have a <dfn id="dfn-class-
 which is the string to include in the string returned from <code>Object.prototype.toString</code>.
 
 If an object has a [=class string=] |classString|, then the object must,
-at the time it is created, have a property whose name is the {{@@toStringTag}} symbol
+at the time it is created, have a property whose name is the {{%Symbol.toStringTag%}} symbol
 with PropertyDescriptor{\[[Writable]]: <emu-val>false</emu-val>,
 \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>,
 \[[Value]]: |classString|}.
@@ -7984,7 +7984,7 @@ JavaScript Array values.
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object,
         [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
-    1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
+    1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{%Symbol.iterator%}}).
     1.  If |method| is <emu-val>undefined</emu-val>,
         [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]
@@ -8681,13 +8681,13 @@ that correspond to the union's [=member types=].
             that is a reference to the object |V|.
     1.  If <a abstract-op>Type</a>(|V|) is Object, then:
         1.  If |types| includes a [=sequence type=], then
-            1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
+            1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{%Symbol.iterator%}}).
             1.  If |method| is not <emu-val>undefined</emu-val>,
                 return the result of
                 [=creating a sequence from an iterable|creating a sequence=]
                 of that type from |V| and |method|.
         1.  If |types| includes a [=frozen array type=], then
-            1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
+            1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{%Symbol.iterator%}}).
             1.  If |method| is not <emu-val>undefined</emu-val>,
                 return the result of
                 [=Creating a frozen array from an iterable|creating a frozen array=]
@@ -10325,7 +10325,7 @@ that bare identifiers matching the property name will not resolve to
 the property in a <code>with</code> statement.  This is achieved by
 including the property name on the
 [=interface prototype object=]'s
-{{@@unscopables}} property's value.
+{{%Symbol.unscopables%}} property's value.
 
 The [{{Unscopable}}]
 extended attribute must
@@ -11234,7 +11234,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             and after performing the following steps,
 
-            1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
+            1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{%Symbol.iterator%}}).
 
             |method| is not <emu-val>undefined</emu-val>, then remove from |S| all
             other entries.
@@ -11392,7 +11392,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     converting the JavaScript values to IDL values.
     (An exception exists when one of the overloads has a [=sequence type=] or [=frozen array type=]
     at the distinguishing argument index.
-    In this case, we attempt to get the {{@@iterator}} property to determine the appropriate
+    In this case, we attempt to get the {{%Symbol.iterator%}} property to determine the appropriate
     overload, and perform the conversion of the distinguishing argument separately before continuing
     with the next step.)
 
@@ -11655,7 +11655,7 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
         1.  Let |desc| be the PropertyDescriptor{\[[Value]]: |unscopableObject|,
             \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>,
             \[[Configurable]]: <emu-val>true</emu-val>}.
-        1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|interfaceProtoObj|, {{@@unscopables}}, |desc|).
+        1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|interfaceProtoObj|, {{%Symbol.unscopables%}}, |desc|).
     1.  If |interface| is not declared with the [{{Global}}] [=extended attribute=], then:
         1.  [=Define the regular attributes=] of |interface| on |interfaceProtoObj| given |realm|.
         1.  [=Define the regular operations=] of |interface| on |interfaceProtoObj| given |realm|.
@@ -12376,7 +12376,7 @@ then there must exist a property with the following characteristics:
     of [=interface=] |definition| on |target|, given [=realm=] |realm|, run the following steps:
 
     1.  If |definition| has an [=indexed property getter=], then:
-        1.  Perform [$DefineMethodProperty$](|target|, {{@@iterator}},
+        1.  Perform [$DefineMethodProperty$](|target|, {{%Symbol.iterator%}},
             {{%Array.prototype.values%}}, false).
         1.  If |definition| has a [=value iterator=], then:
             1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>entries</code>",
@@ -12388,11 +12388,11 @@ then there must exist a property with the following characteristics:
             1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>forEach</code>",
                 {{%Array.prototype.forEach%}}).
     1.  Otherwise, if |definition| has a [=pair iterator=], then:
-        1.  Define the {{@@iterator}} and <code class="idl">entries</code> methods:
+        1.  Define the {{%Symbol.iterator%}} and <code class="idl">entries</code> methods:
             1.  Let |steps| be the following series of steps:
                 1.  Let |jsValue| be [=?=] [$ToObject$](<emu-val>this</emu-val> value).
                 1.  If |jsValue| [=is a platform object=], then [=perform a security check=],
-                    passing |jsValue|, "<code>@@iterator</code>", and "<code>method</code>".
+                    passing |jsValue|, "<code>%Symbol.iterator%</code>", and "<code>method</code>".
                 1.  If |jsValue| does not [=implement=] |definition|, then [=JavaScript/throw=] a
                     <l spec=ecmascript>{{TypeError}}</l>.
                 1.  Return a newly created [=default iterator object=] for |definition|, with
@@ -12402,7 +12402,7 @@ then there must exist a property with the following characteristics:
             1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
             1.  Perform [$SetFunctionName$](|F|, "<code>entries</code>").
             1.  Perform [$SetFunctionLength$](|F|, 0).
-            1.  Perform [$DefineMethodProperty$](|target|, {{@@iterator}}, |F|, false).
+            1.  Perform [$DefineMethodProperty$](|target|, {{%Symbol.iterator%}}, |F|, false).
             1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>entries</code>", |F|).
         1.  Define the <code class="idl">keys</code> method:
             1.  Let |steps| be the following series of steps:
@@ -12572,11 +12572,11 @@ and the string "<code> Iterator</code>".
     1.  Assert: |definition| does not have an [=indexed property getter=] or an
         [=iterable declaration=].
     1.  If |definition| has a [=pair asynchronously iterable declaration=], then define the
-        {{@@asyncIterator}} and <code class="idl">entries</code> methods:
+        {{%Symbol.asyncIterator%}} and <code class="idl">entries</code> methods:
         1.  Let |steps| be the following series of steps, given function argument values |args|:
             1.  Let |jsValue| be [=?=] [$ToObject$](<emu-val>this</emu-val> value).
             1.  If |jsValue| [=is a platform object=], then [=perform a security check=], passing
-                |jsValue|, "<code>@@asyncIterator</code>", and "<code>method</code>".
+                |jsValue|, "<code>%Symbol.asyncIterator%</code>", and "<code>method</code>".
             1.  If |jsValue| does not [=implement=] |definition|, then [=JavaScript/throw=] a
                 <l spec=ecmascript>{{TypeError}}</l>.
             1.  Let |idlObject| be the IDL [=interface type=] value that represents a reference to
@@ -12594,7 +12594,7 @@ and the string "<code> Iterator</code>".
         1.  Let |F| be [$CreateBuiltinFunction$](|steps|, « », |realm|).
         1.  Perform [$SetFunctionName$](|F|, "<code>entries</code>").
         1.  Perform [$SetFunctionLength$](|F|, 0).
-        1.  Perform [$DefineMethodProperty$](|target|, {{@@asyncIterator}}, |F|, false).
+        1.  Perform [$DefineMethodProperty$](|target|, {{%Symbol.asyncIterator%}}, |F|, false).
         1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>entries</code>", |F|).
     1.  If |definition| has a [=pair asynchronously iterable declaration=], then define the
         <code class="idl">keys</code> method:
@@ -12620,7 +12620,7 @@ and the string "<code> Iterator</code>".
         1.  Perform [$SetFunctionName$](|F|, "<code>keys</code>").
         1.  Perform [$SetFunctionLength$](|F|, 0).
         1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>keys</code>", |F|).
-    1.  Define the <code class="idl">values</code>, and possibly {{@@asyncIterator}}, methods:
+    1.  Define the <code class="idl">values</code>, and possibly {{%Symbol.asyncIterator%}}, methods:
         1.  Let |steps| be the following series of steps, given function argument values |args|:
             1.  Let |jsValue| be [=?=] [$ToObject$](<emu-val>this</emu-val> value).
             1.  If |jsValue| [=is a platform object=], then [=perform a security check=], passing
@@ -12644,7 +12644,7 @@ and the string "<code> Iterator</code>".
         1.  Perform [$SetFunctionLength$](|F|, 0).
         1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>values</code>", |F|).
         1.  If |definition| has a [=value asynchronously iterable declaration=], then perform [=!=]
-            [$DefineMethodProperty$](|target|, {{@@asyncIterator}}, |F|, false).
+            [$DefineMethodProperty$](|target|, {{%Symbol.asyncIterator%}}, |F|, false).
 </div>
 
 <div algorithm>
@@ -12906,9 +12906,9 @@ with the following characteristics:
     The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>get size</code>".
 
 
-<h5 id="js-map-iterator" oldids="es-map-iterator,es-iterator, es-iterators">@@iterator</h5>
+<h5 id="js-map-iterator" oldids="es-map-iterator,es-iterator, es-iterators">%Symbol.iterator%</h5>
 
-There must exist a data property whose name is the {{@@iterator}} symbol on
+There must exist a data property whose name is the {{%Symbol.iterator%}} symbol on
 |A|'s [=interface prototype object=]
 with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is the [=function object=] that is the value of
@@ -13216,9 +13216,9 @@ with the following characteristics:
     The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>get size</code>".
 
 
-<h5 id="js-set-iterator" oldids="es-set-iterator">@@iterator</h5>
+<h5 id="js-set-iterator" oldids="es-set-iterator">%Symbol.iterator%</h5>
 
-There must exist a data property whose name is the {{@@iterator}} symbol on
+There must exist a data property whose name is the {{%Symbol.iterator%}} symbol on
 |A|'s [=interface prototype object=]
 with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is the [=function object=] that is the value of


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/1314


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1415.html" title="Last updated on Jul 2, 2024, 3:08 AM UTC (d8b4793)">Preview</a> | <a href="https://whatpr.org/webidl/1415/4035d0a...d8b4793.html" title="Last updated on Jul 2, 2024, 3:08 AM UTC (d8b4793)">Diff</a>