### PR TITLE
Introduce a "transferable" algorithm for BufferSource

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9055,6 +9055,21 @@ a reference to the same object that the IDL value represents.
 </div>
 
 <div algorithm>
+    A [=buffer source type=] instance |bufferSource| is
+    <dfn for="BufferSource" export>detachable</dfn> if the following steps return true:
+
+    1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
+        |bufferSource| to a JavaScript value.
+    1.  If |jsArrayBuffer| has a \[[ViewedArrayBuffer]] internal slot, then set |jsArrayBuffer| to
+        |jsArrayBuffer|.\[[ViewedArrayBuffer]].
+    1.  If [$IsSharedArrayBuffer$](|jsArrayBuffer|) is true, then return false.
+    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then return false.
+    1.  If |jsArrayBuffer|.\[[ArrayBufferDetachKey]] is not <emu-val>undefined</emu-val>, then
+        return false.
+    1.  Return true.
+</div>
+
+<div algorithm>
     To <dfn for="ArrayBuffer" export>transfer</dfn> an {{ArrayBuffer}} |arrayBuffer|, optionally
     given a [=realm=] |targetRealm|:
 

--- a/index.bs
+++ b/index.bs
@@ -9056,7 +9056,7 @@ a reference to the same object that the IDL value represents.
 
 <div algorithm>
     A [=buffer source type=] instance |bufferSource| is
-    <dfn for="BufferSource" export>detachable</dfn> if the following steps return true:
+    <dfn for="BufferSource" export>transferable</dfn> if the following steps return true:
 
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |bufferSource| to a JavaScript value.


### PR DESCRIPTION
The new "transferable" algorithm allows an invoker to determine if a BufferSource can be detached without errors before invoking transfer. This is particularly helpful if several buffers are processed in a batch, as the validity of the operation can be determined up front, rather than during processing which could leave the buffers in a mix of states.

See discussion in [1]. A local copy of the algorithm was landed as [2] (as "detachable") but this seems like a useful addition to WebIDL.

1: https://github.com/webmachinelearning/webnn/issues/351
2: https://webmachinelearning.github.io/webnn/#buffersource-detachable

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

*Eliding the checklist since this is a helper algorithm not new functionality, but please ask if more details are desired*


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1419.html" title="Last updated on Jul 18, 2024, 5:31 PM UTC (08fc50a)">Preview</a> | <a href="https://whatpr.org/webidl/1419/3fb6ab4...08fc50a.html" title="Last updated on Jul 18, 2024, 5:31 PM UTC (08fc50a)">Diff</a>