### PR TITLE
Throw, instead of assert, for transferring detached ArrayBuffers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9060,7 +9060,8 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
-    1.  Assert: [$IsDetachedBuffer$](|jsArrayBuffer|) is false.
+    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is false, then [=JavaScript/throw=] a
+        <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |arrayBufferData| be |jsArrayBuffer|.\[[ArrayBufferData]].
     1.  Let |arrayBufferByteLength| be |jsArrayBuffer|.\[[ArrayBufferByteLength]].
     1.  Perform [=?=] [$DetachArrayBuffer$](|jsArrayBuffer|).
@@ -9073,7 +9074,8 @@ a reference to the same object that the IDL value represents.
         value of type {{ArrayBuffer}}.
 
     <p class="note">This will throw an exception under the same circumstances as
-    [=ArrayBuffer/detaching=].
+    [=ArrayBuffer/detaching=], and also for {{ArrayBuffer}}s that are already
+    [=BufferSource/detached=].
 </div>
 
 <h4 id="js-frozen-array" oldids="es-frozen-array">Frozen arrays — FrozenArray&lt;|T|&gt;</h4>


### PR DESCRIPTION
This makes the algorithm more user-friendly, as this is generally the desired behavior, and the algorithm can already throw for other reasons so callers are expected to handle that.

/cc @inexorabletash as this was inspired by your work in https://github.com/whatwg/webidl/pull/1419.

I audited [the callers](https://dontcallmedom.github.io/webdex/t.html#transfer%40%40ArrayBuffer%40dfn) and they are all fine with this. (Most are just referencing the concept of transferring, as these definitions are not yet widely used.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1420.html" title="Last updated on Jul 18, 2024, 1:23 AM UTC (bf45161)">Preview</a> | <a href="https://whatpr.org/webidl/1420/3fb6ab4...bf45161.html" title="Last updated on Jul 18, 2024, 1:23 AM UTC (bf45161)">Diff</a>