### PR TITLE
add [[ErrorData]] slot to DOMExceptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13532,8 +13532,9 @@ the realm given as an argument.
             1.  Let |targetRealm| be [=?=] [$GetFunctionRealm$](|newTarget|).
             1.  Set |prototype| to the [=interface prototype object=] for |interface| in
                 |targetRealm|.
-    1.  Let |instance| be [$MakeBasicObject$](
-        « \[[Prototype]], \[[Extensible]], \[[Realm]], \[[PrimaryInterface]] »).
+    1.  Let |slots| be « \[[Prototype]], \[[Extensible]], \[[Realm]], \[[PrimaryInterface]] ».
+    1.  If |interface| is {{DOMException}}, append \[[ErrorData]] to |slots|.
+    1.  Let |instance| be [$MakeBasicObject$](|slots|).
     1.  Set |instance|.\[[Realm]] to |realm|.
     1.  Set |instance|.\[[PrimaryInterface]] to |interface|.
     1.  Set |instance|.\[[Prototype]] to |prototype|.
@@ -14547,6 +14548,7 @@ The [=class string=] of a [=namespace object=] is the [=namespace=]'s [=identifi
 In the JavaScript binding, the [=interface prototype object=] for {{DOMException}}
 has its \[[Prototype]] [=/internal slot=] set to the intrinsic object {{%Error.prototype%}},
 as defined in the [=create an interface prototype object=] abstract operation.
+It also has an \[[ErrorData]] slot, like all built-in exceptions.
 
 Additionally, if an implementation gives native {{Error}} objects special powers or
 nonstandard properties (such as a <code>stack</code> property),


### PR DESCRIPTION
This is an attempt to fix https://github.com/tc39/proposal-is-error/issues/9.

The intention is to make DOM Exceptions true subclasses of `Error`.

It's possible this PR needs additional changes to simplify/undo #732 - I'm happy to make whatever changes are appropriate.

- [x] At least two implementers are interested (and none opposed):
   * Google
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/49133 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/382104870
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1923733
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=284506
   * Deno: gets it for free from v8
   * Node.js: gets it for free from v8
   * webidl2.js: n/a, i think?
   * widlparser: n/a, i think?
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/606
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

<!-- (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.) -->

This is part of a stage 2 TC39 proposal for `Error.isError`. When it advances to stage 2.7, I'll file the appropriate implementation bugs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1421.html" title="Last updated on Dec 12, 2024, 5:00 AM UTC (fa40209)">Preview</a> | <a href="https://whatpr.org/webidl/1421/e7b2fe1...fa40209.html" title="Last updated on Dec 12, 2024, 5:00 AM UTC (fa40209)">Diff</a>