### PR TITLE
Allow users of "invoke a callback function" to report the exception

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14400,19 +14400,19 @@ described in the previous section).
 
     To <dfn id="invoke-a-callback-function" export>invoke</dfn> a
     [=callback function type=] value |callable| with a [=Web IDL arguments list=] |args|,
-    exception behavior |exceptionBehavior| (either "`report`" or "`rethrow`"),
+    exception behavior |exceptionBehavior| (either "<code>report</code>" or "<code>rethrow</code>"),
     and an optional [=callback this value|callback this value=] |thisArg|,
     perform the following steps.
     These steps will either return an IDL value or throw an exception.
 
     The |exceptionBehavior| argument must be supplied if, and only if, |callable|'s
     [=return type=] is not a [=promise type=]. If |callable|'s return type is neither
-    {{undefined}} nor {{any}}, it may not be "`report`".
+    {{undefined}} nor {{any}}, it may not be "<code>report</code>".
 
     <div class="XXX">
         Until call sites are updated to respect this, specifications which fail to
-        provide a value here when it would be mandatory should be read to supply
-        "`rethrow`".
+        provide a value here when it would be mandatory should be understood as
+        supplying "<code>rethrow</code>".
     </div>
 
     1.  Let |completion| be an uninitialized variable.
@@ -14445,8 +14445,8 @@ described in the previous section).
         1.  [=Clean up after running script=] with |relevant settings|.
         1.  If |completion| is an IDL value, return |completion|.
         1.  [=Assert=]: |completion| is an [=abrupt completion=].
-        1.  If |exceptionBehavior| is "`rethrow`", throw |completion|.\[[Value]].
-        1.  Otherwise, if |exceptionBehavior| is "`report`":
+        1.  If |exceptionBehavior| is "<code>rethrow</code>", throw |completion|.\[[Value]].
+        1.  Otherwise, if |exceptionBehavior| is "<code>report</code>":
             1.  [=Assert=]: |callable|'s [=return type=] is {{undefined}} or {{any}}.
             1.  [=Report an exception=] |completion|.\[[Value]] for |realm|'s [=realm/global object=].
             1.  Return the unique {{undefined}} IDL value.

--- a/index.bs
+++ b/index.bs
@@ -14399,10 +14399,21 @@ described in the previous section).
 <div algorithm>
 
     To <dfn id="invoke-a-callback-function" export>invoke</dfn> a
-    [=callback function type=] value |callable| with a [=Web IDL arguments list=] |args|
+    [=callback function type=] value |callable| with a [=Web IDL arguments list=] |args|,
+    exception behavior |exceptionBehavior| (either "`report`" or "`rethrow`"),
     and an optional [=callback this value|callback this value=] |thisArg|,
     perform the following steps.
     These steps will either return an IDL value or throw an exception.
+
+    The |exceptionBehavior| argument must be supplied if, and only if, |callable|'s
+    [=return type=] is not a [=promise type=]. If |callable|'s return type is neither
+    {{undefined}} nor {{any}}, it may not be "`report`".
+
+    <div class="XXX">
+        Until call sites are updated to respect this, specifications which fail to
+        provide a value here when it would be mandatory should be read to supply
+        "`rethrow`".
+    </div>
 
     1.  Let |completion| be an uninitialized variable.
     1.  If |thisArg| was not given, let |thisArg| be <emu-val>undefined</emu-val>.
@@ -14433,8 +14444,13 @@ described in the previous section).
         1.  [=Clean up after running a callback=] with |stored settings|.
         1.  [=Clean up after running script=] with |relevant settings|.
         1.  If |completion| is an IDL value, return |completion|.
-        1.  If |completion| is an [=abrupt completion=] and the callback function has a
-            [=return type=] that is <em>not</em> a [=promise type=], throw |completion|.\[[Value]].
+        1.  [=Assert=]: |completion| is an [=abrupt completion=].
+        1.  If |exceptionBehavior| is "`rethrow`", throw |completion|.\[[Value]].
+        1.  Otherwise, if |exceptionBehavior| is "`report`":
+            1.  [=Assert=]: |callable|'s [=return type=] is {{undefined}} or {{any}}.
+            1.  [=Report an exception=] |completion|.\[[Value]] for |realm|'s [=realm/global object=].
+            1.  Return the unique {{undefined}} IDL value.
+        1.  [=Assert=]: |callable|'s [=return type=] is a [=promise type=].
         1.  Let |rejectedPromise| be [=!=] <a abstract-op>Call</a>({{%Promise.reject%}},
             {{%Promise%}}, «|completion|.\[[Value]]»).
         1.  Return the result of [=converted to an IDL value|converting=]

--- a/index.bs
+++ b/index.bs
@@ -14407,7 +14407,7 @@ described in the previous section).
 
     The |exceptionBehavior| argument must be supplied if, and only if, |callable|'s
     [=return type=] is not a [=promise type=]. If |callable|'s return type is neither
-    {{undefined}} nor {{any}}, it may not be "<code>report</code>".
+    {{undefined}} nor {{any}}, it must be "<code>rethrow</code>".
 
     <div class="XXX">
         Until call sites are updated to respect this, specifications which fail to


### PR DESCRIPTION
This makes it more concise for users to, as is frequently desired for undefined-returning callbacks especially, immediately catch and report the exception rather than needing to handle it themselves.

This isn't appropriate for other types of callback functions, where a result may be expected or the exception needs to be rethrown. Callers need to explicitly decide which behavior they want, unless the callback returns a promise type, in which case exceptions are turned into rejected promises implicitly.

Fixes #1423.

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed): n/a; no normative change
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at: n/a; no normative change
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: n/a; no normative change
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a; no normative change
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1424.html" title="Last updated on Aug 2, 2024, 5:35 AM UTC (000a709)">Preview</a> | <a href="https://whatpr.org/webidl/1424/155ae10...000a709.html" title="Last updated on Aug 2, 2024, 5:35 AM UTC (000a709)">Diff</a>