### PR TITLE
export "is a platform object"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13486,7 +13486,7 @@ and must return {{undefined}}.
 <h3 id="js-platform-objects" oldids="es-platform-objects">Platform objects implementing interfaces</h3>
 
 <div algorithm>
-    A JavaScript value |value| <dfn>is a platform object</dfn> if [$Type$](|value|) is Object and
+    A JavaScript value |value| <dfn export>is a platform object</dfn> if [$Type$](|value|) is Object and
     if |value| has a \[[PrimaryInterface]] internal slot.
 </div>
 


### PR DESCRIPTION
This algo is being used in <https://github.com/w3c/css-houdini-drafts/pull/1127>, but since it's unexported (and thus not linking by default), the author of that PR is dropping down to a manual anchor.