### PR TITLE
Fix Iterator prototype reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12528,7 +12528,7 @@ prototype for [=default iterator objects=]
 for the interface.
 
 The \[[Prototype]] [=/internal slot=] of an [=iterator prototype object=]
-must be {{%IteratorPrototype%}}.
+must be {{%Iterator.prototype%}}.
 
 <div algorithm>
   The <dfn>iterator result</dfn> for a [=value pair=] |pair| and a kind |kind| is given by the


### PR DESCRIPTION
Follows https://github.com/tc39/ecma262/pull/3395. Fixes #1444.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1446.html" title="Last updated on Oct 28, 2024, 4:53 AM UTC (a9d3bf6)">Preview</a> | <a href="https://whatpr.org/webidl/1446/4381866...a9d3bf6.html" title="Last updated on Oct 28, 2024, 4:53 AM UTC (a9d3bf6)">Diff</a>