### PR TITLE
Upgrade QuotaExceededError to a DOMException derived interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5158,6 +5158,11 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
             <td><strong>Deprecated.</strong></td>
             <td><dfn id="dom-domexception-url_mismatch_err" for="DOMException" const export><code>URL_MISMATCH_ERR</code></dfn>&nbsp;(21)</td>
         </tr>
+        <tr class="deprecated">
+            <td>"<code>QuotaExceededError</code>"</td>
+            <td><strong>Deprecated.</strong> Use the {{QuotaExceededError}} {{DOMException}}-derived interface instead.</td>
+            <td><dfn id="dom-domexception-quota_exceeded_err" for="DOMException" const export><code>QUOTA_EXCEEDED_ERR</code></dfn>&nbsp;(22)</td>
+        </tr>
         <tr>
             <td>"<dfn id="timeouterror" exception export><code>TimeoutError</code></dfn>"</td>
             <td>The operation timed out.</td>
@@ -5332,6 +5337,10 @@ The <dfn attribute for="QuotaExceededError">quota</dfn> getter steps are to retu
 
 The <dfn attribute for="QuotaExceededError">requested</dfn> getter steps are to return [=this=]'s
 [=QuotaExceededError/requested=].
+
+<p class="note">The {{QuotaExceededError}} interface inherits the {{DOMException}} interface's {{DOMException/code}}
+getter, which will always return 22. However, relying on this value is discouraged (for both {{QuotaExceededError}} and
+{{DOMException}}); it is better to use the {{DOMException/name}} getter.
 
 <hr>
 

--- a/index.bs
+++ b/index.bs
@@ -5159,11 +5159,6 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
             <td><dfn id="dom-domexception-url_mismatch_err" for="DOMException" const export><code>URL_MISMATCH_ERR</code></dfn>&nbsp;(21)</td>
         </tr>
         <tr>
-            <td>"<dfn id="quotaexceedederror" exception export><code>QuotaExceededError</code></dfn>"</td>
-            <td>The quota has been exceeded.</td>
-            <td><dfn id="dom-domexception-quota_exceeded_err" for="DOMException" const export><code>QUOTA_EXCEEDED_ERR</code></dfn>&nbsp;(22)</td>
-        </tr>
-        <tr>
             <td>"<dfn id="timeouterror" exception export><code>TimeoutError</code></dfn>"</td>
             <td>The operation timed out.</td>
             <td><dfn id="dom-domexception-timeout_err" for="DOMException" const export><code>TIMEOUT_ERR</code></dfn>&nbsp;(23)</td>
@@ -5260,69 +5255,113 @@ certain rules, in order to have a predictable shape for developers. Specifically
 <p class=note>These requirements mean that the inherited {{DOMException/code}} property of these
 interfaces will always return 0.
 
-<div class=example id=example-domexception-derived-interface>
-    The definition for a {{DOMException}} derived interface which carries along an additional
-    "protocol error code", which is derived from what the server sent over some some hypothetical
-    network protocol "protocol X", could look something like this:
-
-    <pre highlight=webidl>
-        [Exposed=Window, Serializable]
-        interface ProtocolXError : DOMException {
-          constructor(optional DOMString message = "", ProtocolXErrorOptions options);
-
-          readonly attribute unsigned long long errorCode;
-        };
-
-        dictionary ProtocolXErrorOptions {
-            required [EnforceRange] unsigned long long errorCode;
-        };
-    </pre>
-
-    Every <code>ProtocolXError</code> instance has an <dfn for="ProtocolXError">error code</dfn>,
-    a number.
-
-    <div algorithm="ProtocolXError constructor">
-        The <b><code>new ProtocolXError(|message|, |options|)</code></b> constructor steps are:
-
-        1.  Set [=this=]'s [=DOMException/name=] to "<code>ProtocolXError</code>".
-        1.  Set [=this=]'s [=DOMException/message=] to |message|.
-        1.  Set [=this=]'s [=ProtocolXError/error code=] to |options|["<code>errorCode</code>"].
-    </div>
-
-    <div algorithm="ProtocolXError errorCode">
-        The <b><code>errorCode</code></b> getter steps are to return [=this=]'s
-        [=ProtocolXError/error code=].
-    </div>
-
-    <code>ProtocolXError</code> objects are [=serializable objects=].
-
-    <div algorithm="ProtocolXError serialization steps">
-        Their [=serialization steps=], given |value| and |serialized|, are:
-
-        1. Run the {{DOMException}} [=serialization steps=] given |value| and |serialized|.
-        1. Set |serialized|.\[[ErrorCode]] to |value|'s [=ProtocolXError/error code=].
-    </div>
-
-    <div algorithm="ProtocolXError deserialization steps">
-        Their [=deserialization steps=], given |serialized| and |value|, are:
-
-        1. Run the {{DOMException}} [=deserialization steps=] given |serialized| and |value|.
-        1. Set |value|'s [=ProtocolXError/error code=] to |serialized|.\[[ErrorCode]].
-    </div>
-</div>
-
 To [=exception/create=] or [=exception/throw=] a {{DOMException}} derived interface, supply its
 [=interface=] [=identifier=] as well as the additional information needed to construct it.
 
 <div class=example id=example-domexception-derived-throwing>
-    <p>To throw an instance of the <code>ProtocolXError</code> exemplified
-    <a href=#example-domexception-derived-interface>above</a>:
+    <p>To throw an instance of {{QuotaExceededError}}:
 
     <blockquote>
-        <p>[=exception/Throw=] a <code>ProtocolXError</code> whose [=ProtocolXError/error code=]
-        is 42.
+        <p>[=exception/Throw=] a {{QuotaExceededError}} whose [=QuotaExceededError/quota=] is 42 and
+        [=QuotaExceededError/requested=] is 50.
     </blockquote>
 </div>
+
+<h4 id="idl-DOMException-derived-predefineds" oldids="example-domexception-derived-interface">Predefined {{DOMException}} derived interfaces</h4>
+
+This standard so far defines one predefined {{DOMException}} derived interface:
+
+<pre class=idl>
+[Exposed=*, Serializable]
+interface QuotaExceededError : DOMException {
+  constructor(optional DOMString message = "", optional QuotaExceededErrorOptions options = {});
+
+  readonly attribute double? quota;
+  readonly attribute double? requested;
+};
+
+dictionary QuotaExceededErrorOptions {
+  double quota;
+  double requested;
+};
+</pre>
+
+The {{QuotaExceededError}} exception can be thrown when a quota is exceeded. It has two properties
+that are optionally present, to give more information to the web developer about their request
+compared to the quota value.
+
+<p class="note">Previous versions of this standard defined "<code>QuotaExceededError</code>" as one
+of the <a href="#idl-DOMException-error-names">base <code>DOMException</code> error names</a>. It
+has been upgraded to a full interface to support including such information.</p>
+
+Every {{QuotaExceededError}} instance has a <dfn for="QuotaExceededError">requested</dfn> and a
+<dfn for="QuotaExceededError">quota</dfn>, both numbers or null. They are both initially null.
+
+<div algorithm>
+    The <dfn constructor for="QuotaExceededError" lt="QuotaExceededError(message, options)">new QuotaExceededError(|message|, |options|)</dfn>
+    constructor steps are:
+
+    1.  Set [=this=]'s [=DOMException/name=] to "<code>QuotaExceededError</code>".
+
+    1.  Set [=this=]'s [=DOMException/message=] to |message|.
+
+    1.  If |options|["{{QuotaExceededErrorOptions/quota}}"] is present, then:
+
+        1.  If |options|["{{QuotaExceededErrorOptions/quota}}"] is less than 0, then throw a
+            {{RangeError}}.
+
+        1.  Set [=this=]'s [=QuotaExceededError/quota=] to
+            |options|["{{QuotaExceededErrorOptions/quota}}"].
+
+    1.  If |options|["{{QuotaExceededErrorOptions/requested}}"] is present, then:
+
+        1.  If |options|["{{QuotaExceededErrorOptions/requested}}"] is less than 0, then throw a
+            {{RangeError}}.
+
+        1.  Set [=this=]'s [=QuotaExceededError/requested=] to
+            |options|["{{QuotaExceededErrorOptions/requested}}"].
+
+    1.  If [=this=]'s [=QuotaExceededError/quota=] is not null, [=this=]'s [=QuotaExceededError/requested=] is not null,
+        and [=this=]'s [=QuotaExceededError/requested=] is less than [=this=]'s [=QuotaExceededError/quota=], then
+        throw a {{RangeError}}.
+</div>
+
+The <dfn attribute for="QuotaExceededError">quota</dfn> getter steps are to return [=this=]'s
+[=QuotaExceededError/quota=].
+
+The <dfn attribute for="QuotaExceededError">requested</dfn> getter steps are to return [=this=]'s
+[=QuotaExceededError/requested=].
+
+<hr>
+
+{{QuotaExceededError}} objects are [=serializable objects=].
+
+<div algorithm="QuotaExceededError serialization steps">
+    Their [=serialization steps=], given |value| and |serialized|, are:
+
+    1. Run the {{DOMException}} [=serialization steps=] given |value| and |serialized|.
+
+    1. Set |serialized|.\[[Quota]] to |value|'s [=QuotaExceededError/quota=].
+
+    1. Set |serialized|.\[[Requested]] to |value|'s [=QuotaExceededError/requested=].
+</div>
+
+<div algorithm="QuotaExceededError deserialization steps">
+    Their [=deserialization steps=], given |serialized| and |value|, are:
+
+    1. Run the {{DOMException}} [=deserialization steps=] given |serialized| and |value|.
+
+    1. Set |value|'s [=QuotaExceededError/quota=] to |serialized|.\[[Quota]].
+
+    1. Set |value|'s [=QuotaExceededError/requested=] to |serialized|.\[[Requested]].
+</div>
+
+<hr>
+
+Specifications that [=exception/create=] or [=exception/throw=] a {{QuotaExceededError}} must not
+provide a [=QuotaExceededError/requested=] and [=QuotaExceededError/quota=] that are both non-null
+and where [=QuotaExceededError/requested=] is less than [=QuotaExceededError/quota=].
+
 
 <h3 id="idl-enums">Enumerations</h3>
 
@@ -6651,7 +6690,8 @@ There is no way to represent a constant observable array value in IDL.
 
         1.  If |employee| is not allowed to enter the building today, then throw a
             "{{NotAllowedError}}" {{DOMException}}.
-        1.  If |index| is greater than 200, then throw a "{{QuotaExceededError}}" {{DOMException}}.
+        1.  If |index| is greater than or equal to 200, then throw a {{QuotaExceededError}} whose
+            [=QuotaExceededError/quota=] is 200 and [=QuotaExceededError/requested=] is |index|.
         1.  Put |employee| to work!
 
         The [=observable array attribute/delete an indexed value=] algorithm for

--- a/index.bs
+++ b/index.bs
@@ -5306,7 +5306,7 @@ null.
 
     1.  Set [=this=]'s [=DOMException/message=] to |message|.
 
-    1.  If |options|["{{QuotaExceededErrorOptions/quota}}"] is present, then:
+    1.  If |options|["{{QuotaExceededErrorOptions/quota}}"] is present:
 
         1.  If |options|["{{QuotaExceededErrorOptions/quota}}"] is less than 0, then throw a
             {{RangeError}}.
@@ -5314,7 +5314,7 @@ null.
         1.  Set [=this=]'s [=QuotaExceededError/quota=] to
             |options|["{{QuotaExceededErrorOptions/quota}}"].
 
-    1.  If |options|["{{QuotaExceededErrorOptions/requested}}"] is present, then:
+    1.  If |options|["{{QuotaExceededErrorOptions/requested}}"] is present:
 
         1.  If |options|["{{QuotaExceededErrorOptions/requested}}"] is less than 0, then throw a
             {{RangeError}}.

--- a/index.bs
+++ b/index.bs
@@ -5294,8 +5294,9 @@ compared to the quota value.
 of the <a href="#idl-DOMException-error-names">base <code>DOMException</code> error names</a>. It
 has been upgraded to a full interface to support including such information.</p>
 
-Every {{QuotaExceededError}} instance has a <dfn for="QuotaExceededError">requested</dfn> and a
-<dfn for="QuotaExceededError">quota</dfn>, both numbers or null. They are both initially null.
+Every {{QuotaExceededError}} instance has a <dfn export for="QuotaExceededError">requested</dfn> and
+a <dfn export for="QuotaExceededError">quota</dfn>, both numbers or null. They are both initially
+null.
 
 <div algorithm>
     The <dfn constructor for="QuotaExceededError" lt="QuotaExceededError(message, options)">new QuotaExceededError(|message|, |options|)</dfn>


### PR DESCRIPTION
### The proposal

The web platform benefits from having a type of exception that tells you about when you exceed quotas. In some cases, it can be helpful to tell you what the quota was, and by how much you exceeded it. https://github.com/webmachinelearning/writing-assistance-apis/issues/5 gives one specific use case.

The web platform already has an exception type for telling you when you exceed quotas: it is `DOMException`, with the specific `name` property set to `"QuotaExceededError"`. However, this does not allow carrying additional information.

This PR proposes removing `"QuotaExceededError"` from the list of built-in `DOMException` names, and instead creates a class named `QuotaExceededError` that derives from `DOMException` and has the additional optional properties `quota` and `requested`. We propose that all instances of specs that throw `"QuotaExceededError"` `DOMException`s get upgraded to instead throw `QuotaExceededError`s. For now, such specs would leave the `quota` and `requested` properties at their default value of `null`, but they could eventually upgrade to include that data, if it's useful for their use case (and isn't, e.g., a privacy leak).

### Alternative considered

The most promising alternative considered was to add a new class that sits alongside `"QuotaExceededError"` `DOMException`. Maybe it would be called `QuotaExceededErrorWithDetails`, or maybe we could even call it `QuotaExceededError` despite the confusion this might cause. But it would be undesirable for the web platform to have two types of quota-exceeded errors, with different APIs giving different ones. So, because we believe the compat implications are not too bad, we're interested in trying this upgrade route instead.

There are other possibilities, such as using custom bindings to sometimes add properties to base `"QuotaExceededError"` `DOMException` instances, or trying to add some generic additional information capability to the base `DOMException` class. However, these don't fit well with how classes work on the web platform, with getters providing predefined data on a per-class basis. They would be hacky to maintain both in specs and implementations, and a bit surprising for web developers as well due to the mismatch with other web platform classes.

### Compat considerations

The following coding patterns will work unchanged if we upgrade all `"QuotaExceededError"` `DOMException`s to `QuotaExceedError`s:

- `ex instanceof DOMException`
- `ex.name === "QuotaExceededError"`
- `DOMException.QUOTA_EXCEEDED_ERR === 22`
- `(new DOMException("message", "QuotaExceededError")).name === "QuotaExceededError"`
- `(new DOMException("message", "QuotaExceededError")).code === DOMException.QUOTA_EXCEEDED_ERR`
- `ex.code === DOMException.QUOTA_EXCEEDED_ERR`
- `ex.code === 22`

The following coding patterns will start giving different answers:

- `ex.constructor === DOMException`
- `ex.constructor.name === "DOMException"`

We believe that these coding patterns are quite rare. See, for example, [these GitHub search results](https://github.com/search?q=lang%3Ats+OR+lang%3Ajs+%22.constructor+%3D%3D%3D+DOMException%22&type=code), which show only a couple instances of `.constructor` testing (repeated in a few forks).

The tests like `ex instanceof DOMException` and `ex.name === "QuotaExceededError"` are much more common, and commonly seen in documentation. (See, e.g., [these GitHub search results](https://github.com/search?q=lang%3Ats+OR+lang%3Ajs+%22.name+%3D%3D%3D+%5C%22QuotaExceededError%5C%22%22+OR+%22.name+%3D%3D%3D+%27QuotaExceededError%27%22&type=code).)

Furthermore, since quotas being exceeded is a relatively rare thing to happen on the web, we suspect that the combination of these rare coding patterns with this rare type of `DOMException` means the impacted number of page views will be extremely small.

We could add some use counters for these coding patterns, but they would be sloppy. In particular, we could count cases where `.constructor` is accessed, but not cases where it is compared to `DOMException`, so any count would be inflated by generic constructor-accessing code, and not really tell us much about the problematic coding pattern.

Nevertheless, there's definitely some compat risk. So the best rollout plan here would probably be for Chromium to cautiously take the lead and report back if it sticks, before necessarily merging changes to all the relevant specs.

---

**Proposed commit message**:

Upgrade QuotaExceededError to a DOMException derived interface

Closes #1463.

---

Labeling "do not merge yet" as we should also create PRs for these specs, and we probably don't want to merge until we see if this sticks in Chromium:

- [x] https://fs.spec.whatwg.org/: https://github.com/whatwg/fs/pull/171
- [x] https://html.spec.whatwg.org/: https://github.com/whatwg/html/pull/11440
- [x] https://wicg.github.io/handwriting-recognition/: https://github.com/WICG/handwriting-recognition/pull/38
- [x] https://webmachinelearning.github.io/writing-assistance-apis/: https://github.com/webmachinelearning/writing-assistance-apis/pull/72
- [x] https://w3c.github.io/IndexedDB/: https://github.com/w3c/IndexedDB/pull/463
- [x] https://w3c.github.io/ServiceWorker/: https://github.com/w3c/ServiceWorker/pull/1782
- [x] https://w3c.github.io/webcodecs/: https://github.com/w3c/webcodecs/pull/898

The following cases did not need PRs because they were using inaccurate spec text (just `QuotaExceededError`, instead of `"QuotaExceededError"` `DOMException`), which has now become correct by accident:

- [x] https://w3c.github.io/media-source/
- [x] https://w3c.github.io/webcrypto/
- [x] https://w3c.github.io/webtransport/

----

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Gecko is supportive if Chromium finds the compat risk to be reasonable, per [2025-02-06 WHATNOT meeting](https://github.com/whatwg/html/issues/10972#:~:text=olli:%20there%20was%20an%20internal%20thread%20about%20this%2C%20and%20Yoav%20said%20it%20sounds%20like%20a%20good%20idea.%20a%20bit%20worried%20about%20compat%2C%20but%20if%20chromium%20is%20willing%20to%20try%20it)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/53645
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/406162261
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1976159
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=295570
   * Deno: https://github.com/denoland/deno/issues/30028
   * Node.js: https://github.com/nodejs/node/issues/58987
   * webidl2.js: N/A
   * widlparser: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/whatwg/webidl/pull/1465
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1465.html" title="Last updated on Jul 28, 2025, 4:53 AM UTC (cf2708e)">Preview</a> | <a href="https://whatpr.org/webidl/1465/90b5184...cf2708e.html" title="Last updated on Jul 28, 2025, 4:53 AM UTC (cf2708e)">Diff</a>