### PR TITLE
Editorial: Add a Web Platform Design Principles link for `[Exposed=*]`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9579,11 +9579,12 @@ The <dfn>own exposure set</dfn> is either a [=/set=] of identifiers or the speci
      :: The [=own exposure set=] is <code>*</code>.
 </dl>
 
-<p class="advisement">
+<p class="note">
     <code>[Exposed=*]</code> is to be used with care.
     It is only appropriate when an API does not expose significant new capabilities.
     If the API might be restricted or disabled in some environments,
     it is preferred to list the globals explicitly.
+    See [[DESIGN-PRINCIPLES#expose-everywhere|the Web Platform Design Principles]].
 </p>
 
 <div algorithm>


### PR DESCRIPTION
In w3ctag/design-principles#510, the TAG's Design Principles document added a section on considerations for exposing an interface everywhere (`[Exposed=*]`). This patch links to that section in the definition of `[Exposed=*]`.

Additionally, the paragraph where that link is added used to have `class="advisement"`, which has no styles or any apparent special meaning. This patch changes it to `class="note"`, which was probably the intention.