### PR TITLE
Do not throw if the attribute setter is called with no arguments

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12264,8 +12264,8 @@ in which case they are exposed on every object that [=implements=] the interface
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
-        1.  If no arguments were passed, then [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
-        1.  Let |V| be the value of the first argument passed.
+        1.  Let |V| be <emu-val>undefined</emu-val>.
+        1.  If any arguments were passed, then set |V| to the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
         1.  Let |idlObject| be null.
         1.  If |attribute| is a [=regular attribute=]:


### PR DESCRIPTION
Do not throw if the attribute setter is called with no arguments

This is for https://github.com/whatwg/webidl/issues/1497 .

This changes the attribute setter not to throw if it's called with no arguments (this can happen only if the setter function is extracted from the property descriptor and directly called), and instead treat it as if `undefined` is passed.

No browsers had been following the previous behavior, and the updated behavior matches WebKit.

- [x] At least two implementers are interested (and none opposed):
   * WebKit (https://github.com/whatwg/webidl/issues/1497#issuecomment-3019315858)
   * Chromium (https://github.com/whatwg/webidl/issues/1497#issuecomment-3021612289, https://github.com/whatwg/webidl/issues/1497#issuecomment-3021622854)
   * Gecko (https://github.com/whatwg/webidl/issues/1497#issuecomment-3028206420 , and patch is ready in https://bugzilla.mozilla.org/show_bug.cgi?id=1974950)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * The patch part 2 in https://bugzilla.mozilla.org/show_bug.cgi?id=1974950
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/429221315
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1974950
   * WebKit: (Already matches the updated behavior, and it's passing the WPT added in the above)
   * Deno: https://github.com/denoland/deno/issues/30167
   * Node.js: (unaffected)
   * webidl2.js: (unaffected)
   * widlparser: (unaffected)
- ~[MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed~: (extracting the setter function and directly calling it shouldn't be done in regular usage, and there won't be any need to describe this behavior in MDN)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1498.html" title="Last updated on Jul 22, 2025, 8:24 AM UTC (b080ed2)">Preview</a> | <a href="https://whatpr.org/webidl/1498/122e9da...b080ed2.html" title="Last updated on Jul 22, 2025, 8:24 AM UTC (b080ed2)">Diff</a>