### PR TITLE
Introduce new extended attribute grammars

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6802,7 +6802,7 @@ grammar symbol matches nearly any sequence of tokens, however the
 defined in this document only accept a more restricted syntax.
 Any extended attribute encountered in an
 [=IDL fragment=] is
-matched against the following five grammar symbols to determine
+matched against the following eight grammar symbols to determine
 which form (or forms) it is in:
 
 <table class="vert data">
@@ -6853,6 +6853,39 @@ which form (or forms) it is in:
         </td>
         <td>
             <code>[PutForwards=name]</code>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <emu-nt><a href="#prod-ExtendedAttributeString">ExtendedAttributeString</a></emu-nt>
+        </td>
+        <td>
+            <dfn id="dfn-xattr-string" for="extended attribute" export>takes a string</dfn>
+        </td>
+        <td>
+            <code>[Reflect="popover"]</code>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <emu-nt><a href="#prod-ExtendedAttributeNumber">ExtendedAttributeNumber</a></emu-nt>
+        </td>
+        <td>
+            <dfn id="dfn-xattr-number" for="extended attribute" export>takes an integer or decimal</dfn>
+        </td>
+        <td>
+            <code>[ReflectDefault=2.0]</code>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <emu-nt><a href="#prod-ExtendedAttributeIntegerList">ExtendedAttributeIntegerList</a></emu-nt>
+        </td>
+        <td>
+            <dfn id="dfn-xattr-integer-list" for="extended attribute" export>takes an integer list</dfn>
+        </td>
+        <td>
+            <code>[ReflectRange=(2, 600)]</code>
         </td>
     </tr>
     <tr>
@@ -6988,6 +7021,17 @@ five forms are allowed.
         ε
 </pre>
 
+<pre class="grammar" id="prod-IntegerList">
+    IntegerList :
+        integer Integers
+</pre>
+
+<pre class="grammar" id="prod-Integers">
+    Integers :
+        "," integer Integers
+        ε
+</pre>
+
 <pre class="grammar" id="prod-ExtendedAttributeNoArgs">
     ExtendedAttributeNoArgs :
         identifier
@@ -7003,6 +7047,17 @@ five forms are allowed.
         identifier "=" identifier
 </pre>
 
+<pre class="grammar" id="prod-ExtendedAttributeString">
+    ExtendedAttributeString :
+        identifier "=" string
+</pre>
+
+<pre class="grammar" id="prod-ExtendedAttributeNumber">
+    ExtendedAttributeNumber :
+        identifier "=" integer
+        identifier "=" decimal
+</pre>
+
 <pre class="grammar" id="prod-ExtendedAttributeWildcard">
     ExtendedAttributeWildcard :
         identifier "=" "*"
@@ -7011,6 +7066,11 @@ five forms are allowed.
 <pre class="grammar" id="prod-ExtendedAttributeIdentList">
     ExtendedAttributeIdentList :
         identifier "=" "(" IdentifierList ")"
+</pre>
+
+<pre class="grammar" id="prod-ExtendedAttributeIntegerList">
+    ExtendedAttributeIntegerList :
+        identifier "=" "(" IntegerList ")"
 </pre>
 
 <pre class="grammar" id="prod-ExtendedAttributeNamedArgList">

--- a/index.bs
+++ b/index.bs
@@ -6868,10 +6868,21 @@ which form (or forms) it is in:
     </tr>
     <tr>
         <td>
-            <emu-nt><a href="#prod-ExtendedAttributeNumber">ExtendedAttributeNumber</a></emu-nt>
+            <emu-nt><a href="#prod-ExtendedAttributeInteger">ExtendedAttributeInteger</a></emu-nt>
         </td>
         <td>
-            <dfn id="dfn-xattr-number" for="extended attribute" export>takes an integer or decimal</dfn>
+            <dfn id="dfn-xattr-integer" for="extended attribute" export>takes an integer</dfn>
+        </td>
+        <td>
+            <code>[ReflectDefault=2]</code>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <emu-nt><a href="#prod-ExtendedAttributeDecimal">ExtendedAttributeDecimal</a></emu-nt>
+        </td>
+        <td>
+            <dfn id="dfn-xattr-decimal" for="extended attribute" export>takes a decimal</dfn>
         </td>
         <td>
             <code>[ReflectDefault=2.0]</code>
@@ -7052,9 +7063,13 @@ five forms are allowed.
         identifier "=" string
 </pre>
 
-<pre class="grammar" id="prod-ExtendedAttributeNumber">
-    ExtendedAttributeNumber :
+<pre class="grammar" id="prod-ExtendedAttributeInteger">
+    ExtendedAttributeInteger :
         identifier "=" integer
+</pre>
+
+<pre class="grammar" id="prod-ExtendedAttributeDecimal">
+    ExtendedAttributeDecimal :
         identifier "=" decimal
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -6802,7 +6802,7 @@ grammar symbol matches nearly any sequence of tokens, however the
 defined in this document only accept a more restricted syntax.
 Any extended attribute encountered in an
 [=IDL fragment=] is
-matched against the following eight grammar symbols to determine
+matched against the following grammar symbols to determine
 which form (or forms) it is in:
 
 <table class="vert data">


### PR DESCRIPTION
Introduce four new extended attribute grammars

These new grammars will be used by the HTML spec for attribute reflection extended attributes. ExtendedAttributeString (`[Reflect="foo"]`), ExtendedAttributeInteger (`[ReflectDefault=1]`), ExtendedAttributeDecimal (`[ReflectDefault=1.0]`) and ExtendedAttributeIntegerList (`[ReflectRange=(1,100)]`) are added.

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * N/A
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
   * Deno: N/A
   * Node.js: N/A
   * webidl2.js: https://github.com/w3c/webidl2.js/issues/817
   * widlparser: https://github.com/plinss/widlparser/issues/91
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1503.html" title="Last updated on Jul 17, 2025, 6:09 PM UTC (191ffa7)">Preview</a> | <a href="https://whatpr.org/webidl/1503/d5cc64c...191ffa7.html" title="Last updated on Jul 17, 2025, 6:09 PM UTC (191ffa7)">Diff</a>