### PR TITLE
Editorial: replace `IsResizableArrayBuffer` with `IsFixedLengthArrayBuffer`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -91,9 +91,6 @@ urlPrefix: https://tc39.es/ecma262/; spec: ecmascript
         url: sec-object-type
             text: is an Object
             text: is not an Object
-urlPrefix: https://tc39.es/proposal-resizablearraybuffer/; spec: RESIZABLE-BUFFERS-PROPOSAL
-    type: abstract-op
-        text: IsResizableArrayBuffer; url: sec-isresizablearraybuffer
 </pre>
 
 <pre class=biblio>
@@ -9111,13 +9108,13 @@ that correspond to the union's [=member types=].
 A value of an IDL {{ArrayBuffer}} is represented by an object of the corresponding JavaScript class.
 If it is not [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
 [=extended attribute=], it can only be backed by JavaScript <l spec=ecmascript>{{ArrayBuffer}}</l>
-objects |V| for which <a abstract-op>IsResizableArrayBuffer</a>(|V|) is false.
+objects |V| for which <a abstract-op>IsFixedLengthArrayBuffer</a>(|V|) is true.
 
 A value of an IDL {{SharedArrayBuffer}} is represented by an object of the corresponding JavaScript
 class. If it is not [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
 [=extended attribute=], it can only be backed by JavaScript
 <l spec=ecmascript>{{SharedArrayBuffer}}</l> objects |V| for which
-<a abstract-op>IsResizableArrayBuffer</a>(|V|) is false.
+<a abstract-op>IsFixedLengthArrayBuffer</a>(|V|) is true.
 
 Values of the IDL [=buffer view types=] are represented by objects of the corresponding JavaScript
 class, with the following additional restrictions on those objects.
@@ -9127,7 +9124,7 @@ class, with the following additional restrictions on those objects.
         If the type is not [=extended attributes associated with|associated with=] either the
         [{{AllowResizable}}] or [{{AllowShared}}] [=extended attribute=], if applicable, they can
         only be backed by JavaScript <l spec=ecmascript>{{ArrayBuffer}}</l> objects |V| for which <a
-        abstract-op>IsResizableArrayBuffer</a>(|V|) is false.
+        abstract-op>IsFixedLengthArrayBuffer</a>(|V|) is true.
     </li>
     <li>
         If the type is [=extended attributes associated with|associated with=] the
@@ -9140,7 +9137,7 @@ class, with the following additional restrictions on those objects.
         [=extended attribute=] but not with the [{{AllowResizable}}] [=extended attribute=], they
         can only be backed by JavaScript <l spec=ecmascript>{{ArrayBuffer}}</l> and
         <l spec=ecmascript>{{SharedArrayBuffer}}</l> objects |V| for which
-        <a abstract-op>IsResizableArrayBuffer</a>(|V|) is false.
+        <a abstract-op>IsFixedLengthArrayBuffer</a>(|V|) is true.
     </li>
     <li>
         If the type is [=extended attributes associated with|associated with=] both the
@@ -9163,7 +9160,7 @@ class, with the following additional restrictions on those objects.
         a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
-        [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|) is true,
+        [=extended attribute=], and <a abstract-op>IsFixedLengthArrayBuffer</a>(|V|) is false,
         then [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{ArrayBuffer}} value that is a reference
         to the same object as |V|.
@@ -9181,7 +9178,7 @@ class, with the following additional restrictions on those objects.
         a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
-        [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|) is true,
+        [=extended attribute=], and <a abstract-op>IsFixedLengthArrayBuffer</a>(|V|) is false,
         then [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{SharedArrayBuffer}} value that is a reference
         to the same object as |V|.
@@ -9201,7 +9198,7 @@ class, with the following additional restrictions on those objects.
         then [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
-        [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
+        [=extended attribute=], and <a abstract-op>IsFixedLengthArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is false,
         then [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL {{DataView}} value that is a reference
         to the same object as |V|.
@@ -9236,7 +9233,7 @@ class, with the following additional restrictions on those objects.
         then [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowResizable}}]
-        [=extended attribute=], and <a abstract-op>IsResizableArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is true,
+        [=extended attribute=], and <a abstract-op>IsFixedLengthArrayBuffer</a>(|V|.\[[ViewedArrayBuffer]]) is false,
         then [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
     1.  Return the IDL value of type |T| that is a reference to the same object as |V|.
 </div>


### PR DESCRIPTION
As part of https://github.com/tc39/ecma262/pull/3116, the `IsResizableArrayBuffer` abstract op was negated and replaced with `IsFixedLengthArrayBuffer`. This PR updates the spec to use the standardized op.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
