### PR TITLE
Review Draft Publication: September 2025

### DIFF
--- a/review-drafts/2025-09.bs
+++ b/review-drafts/2025-09.bs
@@ -1,5 +1,7 @@
 <pre class="metadata">
 Group: WHATWG
+Status: RD
+Date: 2025-09-15
 H1: Web IDL
 Shortname: webidl
 Text Macro: TWITTER webidl


### PR DESCRIPTION
The [September 2025 Review Draft](https://webidl.spec.whatwg.org/review-drafts/2025-09/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.