### PR TITLE
Fix `BufferSource` algorithms for shared and resizable buffers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9316,6 +9316,7 @@ a reference to the same object that the IDL value represents.
     1.  Let |arrayBuffer| be |bufferSource|.
     1.  Let |offset| be 0.
     1.  Let |length| be |bufferSource|'s [=BufferSource/byte length=].
+    1.  If |length| is 0, then return the empty [=byte sequence=].
     1.  If |bufferSource| is a [=buffer view type=] instance:
         1.  Set |arrayBuffer| to |bufferSource|'s [=underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].

--- a/index.bs
+++ b/index.bs
@@ -9321,8 +9321,8 @@ a reference to the same object that the IDL value represents.
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
     1.  If |length| is 0, then return the empty [=byte sequence=].
 
-        <p class="note">This step is not strictly necessary, since [=the range=] below is empty
-        when |length| is 0. It is spelled out as a fast path for implementations.
+        <p class="note">This step is not strictly necessary, since [=the exclusive range|the range=]
+        below is empty when |length| is 0. It is spelled out as a fast path for implementations.
     1.  Assert: |arrayBuffer| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.

--- a/index.bs
+++ b/index.bs
@@ -9320,6 +9320,9 @@ a reference to the same object that the IDL value represents.
         1.  Set |arrayBuffer| to |bufferSource|'s [=BufferSource/underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
     1.  If |length| is 0, then return the empty [=byte sequence=].
+
+        <p class="note">This step is not strictly necessary, since [=the range=] below is empty
+        when |length| is 0. It is spelled out as a fast path for implementations.
     1.  Assert: |arrayBuffer| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.

--- a/index.bs
+++ b/index.bs
@@ -9317,12 +9317,13 @@ a reference to the same object that the IDL value represents.
     1.  Let |arrayBuffer| be |bufferSource|.
     1.  Let |offset| be 0.
     1.  If |bufferSource| is a [=buffer view type=] instance:
-        1.  Set |arrayBuffer| to |bufferSource|'s [=underlying buffer=].
+        1.  Set |arrayBuffer| to |bufferSource|'s [=BufferSource/underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
-            <p class="note">This will throw an exception if |bufferSource| is
-            [=ArrayBufferView/out of bounds=].
     1.  If |length| is 0, then return the empty [=byte sequence=].
-    1.  [=/Assert=]: |arrayBuffer| is an {{ArrayBuffer}} or {{SharedArrayBuffer}} object.
+
+        <p class="note">This step is not strictly necessary, since [=the range=] below is empty
+        when |length| is 0. It is spelled out as a fast path for implementations.
+    1.  [=/Assert=]: |arrayBuffer| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
     1.  [=/Assert=]: [$IsDetachedBuffer$](|jsArrayBuffer|) is false.
@@ -9331,6 +9332,10 @@ a reference to the same object that the IDL value represents.
         set |bytes|[|i| &minus; |offset|] to [$GetValueFromBuffer$](|jsArrayBuffer|, |i|, Uint8,
         true, Unordered).
     1.  Return |bytes|.
+
+    <p class="note" id="note-get-buffer-source-copy-exceptions">This will throw an exception if
+    |bufferSource| is a {{DataView}} that is [=ArrayBufferView/out of bounds=], since reading its
+    [=BufferSource/byte length=] <a href="#note-BufferSource-byte-length-exceptions">throws</a>.
 </div>
 
 <div algorithm>
@@ -9362,7 +9367,8 @@ a reference to the same object that the IDL value represents.
     [=typed array type=] instance) or {{DataView/byteOffset|DataView.prototype.byteOffset}}
     (for a {{DataView}}). In particular, this deliberately mirrors JavaScript's asymmetry: a
     [=typed array type=] instance that is [=ArrayBufferView/out of bounds=] has a byte offset of
-    0, whereas a {{DataView}} that is [=ArrayBufferView/out of bounds=] instead throws.
+    0, whereas a {{DataView}} that is [=ArrayBufferView/out of bounds=] instead throws an
+    exception.
 </div>
 
 <div algorithm>
@@ -9392,6 +9398,12 @@ a reference to the same object that the IDL value represents.
     {{ArrayBuffer/byteLength|ArrayBuffer.prototype.byteLength}} and
     {{SharedArrayBuffer/byteLength|SharedArrayBuffer.prototype.byteLength}}
     (for a [=buffer type=] instance).
+
+    <p class="note" id="note-BufferSource-byte-length-exceptions">This will throw an exception if
+    |bufferSource| is a {{DataView}} that is [=ArrayBufferView/out of bounds=], which includes the
+    case where it is [=BufferSource/detached=]. Every other [=buffer source type=] instance
+    returns 0 in those cases. This mirrors JavaScript, where only
+    {{DataView/byteLength|DataView.prototype.byteLength}} throws.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -9426,7 +9426,7 @@ a reference to the same object that the IDL value represents.
     <dfn id=arraybuffer-write-startingoffset export for="ArrayBuffer/write,SharedArrayBuffer/write">|startingOffset|</dfn>
     (default 0):
 
-    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=byte length=]
+    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=BufferSource/byte length=]
         &minus; |startingOffset|.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.

--- a/index.bs
+++ b/index.bs
@@ -9359,12 +9359,9 @@ a reference to the same object that the IDL value represents.
                 Seq-Cst).
             1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then return 0.
             1.  Return [$GetViewByteLength$](|viewRecord|).
-    1.  Otherwise, if [$IsSharedArrayBuffer$](|jsBufferSource|) is true:
-        1.  [=/Assert=]: |jsBufferSource| is a {{SharedArrayBuffer}}.
-        1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
     1.  Otherwise:
-        1.  [=/Assert=]: |jsBufferSource| is an {{ArrayBuffer}}.
-        1.  Return |jsBufferSource|.\[[ArrayBufferByteLength]].
+        1.  [=/Assert=]: |jsBufferSource| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
+        1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
 </div>
 <!-- TODO: should this be stricter around not being detached? -->
 

--- a/index.bs
+++ b/index.bs
@@ -9357,7 +9357,8 @@ a reference to the same object that the IDL value represents.
             1.  [=/Assert=]: |jsBufferSource| is a {{DataView}}.
             1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|,
                 Seq-Cst).
-            1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then return 0.
+            1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then [=JavaScript/throw=] a
+                <l spec=ecmascript>{{TypeError}}</l>.
             1.  Return [$GetViewByteLength$](|viewRecord|).
     1.  Otherwise:
         1.  [=/Assert=]: |jsBufferSource| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.

--- a/index.bs
+++ b/index.bs
@@ -9320,9 +9320,6 @@ a reference to the same object that the IDL value represents.
         1.  Set |arrayBuffer| to |bufferSource|'s [=BufferSource/underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
     1.  If |length| is 0, then return the empty [=byte sequence=].
-
-        <p class="note">This step is not strictly necessary, since [=the range=] below is empty
-        when |length| is 0. It is spelled out as a fast path for implementations.
     1.  Assert: |arrayBuffer| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.

--- a/index.bs
+++ b/index.bs
@@ -9351,6 +9351,7 @@ a reference to the same object that the IDL value represents.
             1.  [=/Assert=]: |jsBufferSource| is a [=typed array type=] instance.
             1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|,
                 Seq-Cst).
+            1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, return 0.
             1.  Return [$TypedArrayByteLength$](|taRecord|).
         1.  Otherwise:
             1.  [=/Assert=]: |jsBufferSource| is a {{DataView}}.

--- a/index.bs
+++ b/index.bs
@@ -9351,7 +9351,7 @@ a reference to the same object that the IDL value represents.
             1.  [=/Assert=]: |jsBufferSource| is a [=typed array type=] instance.
             1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|,
                 Seq-Cst).
-            1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, return 0.
+            1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, then return 0.
             1.  Return [$TypedArrayByteLength$](|taRecord|).
         1.  Otherwise:
             1.  [=/Assert=]: |jsBufferSource| is a {{DataView}}.

--- a/index.bs
+++ b/index.bs
@@ -9429,13 +9429,19 @@ a reference to the same object that the IDL value represents.
     {{ArrayBufferView}} |view|, optionally given a
     <dfn export for="ArrayBufferView/write">|startingOffset|</dfn> (default 0):
 
-    1.  [=/Assert=]: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=byte length=] &minus;
-        |startingOffset|.
+    1.  [=/Assert=]: |view| is not [=ArrayBufferView/out of bounds=].
+    1.  [=/Assert=]: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=BufferSource/byte length=]
+        &minus; |startingOffset|.
     1.  Assert: if |view| is not a {{DataView}}, then |bytes|'s [=byte sequence/length=] [=modulo=]
         the [=element size=] of |view|'s type is 0.
-    1.  [=ArrayBuffer/Write=] |bytes| into |view|'s [=underlying buffer=] with
-        <i>[=ArrayBuffer/write/startingOffset=]</i> set to |view|'s [=ArrayBufferView/byte offset=] +
-        |startingOffset|.
+    1.  [=ArrayBuffer/Write=] |bytes| into |view|'s [=BufferSource/underlying buffer=] with
+        <i>[=ArrayBuffer/write/startingOffset=]</i> set to
+        |view|'s [=ArrayBufferView/byte offset=] + |startingOffset|.
+
+    <p class="note">Callers must ensure that |view| is not [=ArrayBufferView/out of bounds=],
+    which also means that it is not [=BufferSource/detached=]. Otherwise, |view|'s
+    [=BufferSource/byte length=] and [=ArrayBufferView/byte offset=] could throw an exception,
+    and assertions must not be observable.
 </div>
 
 <div class="warning">

--- a/index.bs
+++ b/index.bs
@@ -9331,8 +9331,10 @@ a reference to the same object that the IDL value represents.
     1.  Return |bytes|.
 
     <p class="note" id="note-get-buffer-source-copy-exceptions">This will throw an exception if
-    |bufferSource| is a {{DataView}} that is [=ArrayBufferView/out of bounds=], since reading its
-    [=BufferSource/byte length=] <a href="#note-BufferSource-byte-length-exceptions">throws</a>.
+    |bufferSource| is a {{DataView}} that is [=ArrayBufferView/out of bounds=] without being
+    [=BufferSource/detached=], since reading its [=BufferSource/byte length=]
+    <a href="#note-BufferSource-byte-length-exceptions">throws</a>. A [=BufferSource/detached=]
+    |bufferSource| returns the empty [=byte sequence=] in the first step instead.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -9500,18 +9500,15 @@ a reference to the same object that the IDL value represents.
 
 <div algorithm="ArrayBuffer/transfer">
     To <dfn for="ArrayBuffer" export>transfer</dfn> an {{ArrayBuffer}} |arrayBuffer|, optionally
-    given <dfn export for="ArrayBuffer/transfer">|preserveResizability|</dfn> (default false):
+    given a boolean <dfn export for="ArrayBuffer/transfer">|preserveResizability|</dfn>
+    (default false):
 
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
-    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then [=JavaScript/throw=] a
-        <l spec=ecmascript>{{TypeError}}</l>.
-    1.  If |preserveResizability| is true:
-        1.  Let |jsTransferred| be [=?=] [$ArrayBufferCopyAndDetach$](|jsArrayBuffer|, undefined,
-            Preserve-Resizability).
-    1.  Otherwise:
-        1.  Let |jsTransferred| be [=?=] [$ArrayBufferCopyAndDetach$](|jsArrayBuffer|, undefined,
-            Fixed-Length).
+    1.  Let |resizability| be Preserve-Resizability if |preserveResizability| is true; otherwise
+        Fixed-Length.
+    1.  Let |jsTransferred| be [=?=] [$ArrayBufferCopyAndDetach$](|jsArrayBuffer|,
+        <emu-val>undefined</emu-val>, |resizability|).
     1.  Return the result of [=converted to an IDL value|converting=] |jsTransferred| to an IDL
         value of type {{ArrayBuffer}}.
 

--- a/index.bs
+++ b/index.bs
@@ -9350,17 +9350,17 @@ a reference to the same object that the IDL value represents.
         1.  If |jsBufferSource| has a \[[TypedArrayName]] [=/internal slot=]:
             1.  Assert: |jsBufferSource| is a [=typed array type=] instance.
             1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|,
-                Unordered).
+                Seq-Cst).
             1.  Return [$TypedArrayByteLength$](|taRecord|).
         1.  Otherwise:
             1.  Assert: |jsBufferSource| is a {{DataView}}.
             1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|,
-                Unordered).
+                Seq-Cst).
             1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, return 0.
             1.  Return [$GetViewByteLength$](|viewRecord|).
     1.  Otherwise, if [$IsSharedArrayBuffer$](|jsBufferSource|) is true, then:
         1.  Assert: |jsBufferSource| is a {{SharedArrayBuffer}}.
-        1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Unordered).
+        1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
     1.  Otherwise:
         1.  Assert: |jsBufferSource| is an {{ArrayBuffer}}.
         1.  Return |jsBufferSource|.\[[ArrayBufferByteLength]].

--- a/index.bs
+++ b/index.bs
@@ -9315,7 +9315,7 @@ a reference to the same object that the IDL value represents.
     1.  Let |arrayBuffer| be |bufferSource|.
     1.  Let |offset| be 0.
     1.  Let |length| be |bufferSource|'s [=BufferSource/byte length=].
-    1.  If |bufferSource| is a [=buffer view type=] instance, then:
+    1.  If |bufferSource| is a [=buffer view type=] instance:
         1.  Set |arrayBuffer| to |bufferSource|'s [=underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
     1.  Assert: |arrayBuffer| is an {{ArrayBuffer}} or {{SharedArrayBuffer}} object.
@@ -9336,7 +9336,7 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=] |view| to
         a JavaScript value.
-    1.  If [$IsArrayBufferViewOutOfBounds$](|jsView|) is true, throw a {{TypeError}} exception.
+    1.  If [$IsArrayBufferViewOutOfBounds$](|jsView|) is true, then throw a {{TypeError}} exception.
     1.  Return |jsView|.\[[ByteOffset]].
 </div>
 
@@ -9346,7 +9346,7 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsBufferSource| be the result of [=converted to a JavaScript value|converting=]
         |bufferSource| to a JavaScript value.
-    1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=], then:
+    1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=]:
         1.  If |jsBufferSource| has a \[[TypedArrayName]] [=/internal slot=]:
             1.  Assert: |jsBufferSource| is a [=typed array type=] instance.
             1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|,
@@ -9356,9 +9356,9 @@ a reference to the same object that the IDL value represents.
             1.  Assert: |jsBufferSource| is a {{DataView}}.
             1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|,
                 Seq-Cst).
-            1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, return 0.
+            1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then return 0.
             1.  Return [$GetViewByteLength$](|viewRecord|).
-    1.  Otherwise, if [$IsSharedArrayBuffer$](|jsBufferSource|) is true, then:
+    1.  Otherwise, if [$IsSharedArrayBuffer$](|jsBufferSource|) is true:
         1.  Assert: |jsBufferSource| is a {{SharedArrayBuffer}}.
         1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
     1.  Otherwise:
@@ -9473,10 +9473,10 @@ a reference to the same object that the IDL value represents.
         |arrayBuffer| to a JavaScript value.
     1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then [=JavaScript/throw=] a
         <l spec=ecmascript>{{TypeError}}</l>.
-    1.  If |preserveResizability| is true, then:
+    1.  If |preserveResizability| is true:
         1.  Let |jsTransferred| be [=?=] [$ArrayBufferCopyAndDetach$](|jsArrayBuffer|, undefined,
             Preserve-Resizability).
-    1.  Otherwise,
+    1.  Otherwise:
         1.  Let |jsTransferred| be [=?=] [$ArrayBufferCopyAndDetach$](|jsArrayBuffer|, undefined,
             Fixed-Length).
     1.  Return the result of [=converted to an IDL value|converting=] |jsTransferred| to an IDL

--- a/index.bs
+++ b/index.bs
@@ -9519,11 +9519,12 @@ a reference to the same object that the IDL value represents.
             <a href="#note-ArrayBuffer-detach-exceptions">explained in that algorithm's
             definition</a>;
         *   |arrayBuffer| is already [=BufferSource/detached=];
-        *   Sufficient memory cannot be allocated in |realm|. Generally this will only be the case
-            if |realm| is in a different [=agent cluster=] than the one in which |arrayBuffer| was
-            allocated. If they are in the same [=agent cluster=], then implementations will just
-            change the backing pointers to get the same observable results with better performance
-            and no allocations.
+        *   Sufficient memory cannot be allocated in the [=current realm=], which is the [=realm=]
+            in which the new {{ArrayBuffer}} is allocated. Generally this will only be the case if
+            the [=current realm=] is in a different [=agent cluster=] than the one in which
+            |arrayBuffer| was allocated. If they are in the same [=agent cluster=], then
+            implementations will just change the backing pointers to get the same observable
+            results with better performance and no allocations.
     </div>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -9334,6 +9334,15 @@ a reference to the same object that the IDL value represents.
 </div>
 
 <div algorithm>
+    An {{ArrayBufferView}} |view| is <dfn export for="ArrayBufferView">out of bounds</dfn>
+    if the following steps return true:
+
+    1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=]
+        |view| to a JavaScript value.
+    1.  Return [$IsArrayBufferViewOutOfBounds$](|jsView|).
+</div>
+
+<div algorithm>
     The <dfn export for="ArrayBufferView">byte offset</dfn> of an {{ArrayBufferView}}
     |view| is the value returned by the following steps:
 
@@ -9380,15 +9389,6 @@ a reference to the same object that the IDL value represents.
             <p class="note">The above substeps are equivalent to
             {{ArrayBuffer/byteLength|ArrayBuffer.prototype.byteLength}} or
             {{SharedArrayBuffer/byteLength|SharedArrayBuffer.prototype.byteLength}}.
-</div>
-
-<div algorithm>
-    An {{ArrayBufferView}} |view| is <dfn export for="ArrayBufferView">out of bounds</dfn>
-    if the following steps return true:
-
-    1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=]
-        |view| to a JavaScript value.
-    1.  Return [$IsArrayBufferViewOutOfBounds$](|jsView|).
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -9312,17 +9312,15 @@ a reference to the same object that the IDL value represents.
     To <dfn id="dfn-get-buffer-source-copy" export lt="get a copy of the buffer source|get a copy of the bytes held by the buffer source">get a copy of the bytes held by the buffer source</dfn>
     given a [=buffer source type=] instance |bufferSource|:
 
-    1.  Let |jsBufferSource| be the result of [=converted to a JavaScript value|converting=]
-        |bufferSource| to a JavaScript value.
-    1.  Let |jsArrayBuffer| be |jsBufferSource|.
+    1.  Let |arrayBuffer| be |bufferSource|.
     1.  Let |offset| be 0.
-    1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=], then:
-        1.  Set |jsArrayBuffer| to |jsBufferSource|.\[[ViewedArrayBuffer]].
-        1.  Set |offset| to |jsBufferSource|'s [=ArrayBufferView/byte offset=].
-    1.  Otherwise:
-        1.  Assert: |jsBufferSource| is an {{ArrayBuffer}} or
-            {{SharedArrayBuffer}} object.
-    1.  Let |length| be |jsBufferSource|'s [=BufferSource/byte length=].
+    1.  Let |length| be |bufferSource|'s [=BufferSource/byte length=].
+    1.  If |bufferSource| is a [=buffer view type=] instance, then:
+        1.  Set |arrayBuffer| to |bufferSource|'s [=underlying buffer=].
+        1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
+    1.  Assert: |arrayBuffer| is an {{ArrayBuffer}} or {{SharedArrayBuffer}} object.
+    1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
+        |arrayBuffer| to a JavaScript value.
     1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then return the empty
         [=byte sequence=].
     1.  Let |bytes| be a new [=byte sequence=] of [=byte sequence/length=] equal to |length|.

--- a/index.bs
+++ b/index.bs
@@ -9336,14 +9336,7 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=] |view| to
         a JavaScript value.
-    1.  If |jsView| has a \[[TypedArrayName]] [=/internal slot=]:
-        1.  Assert: |jsView| is a [=typed array type=] instance.
-        1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsView|, Unordered).
-        1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, throw a {{TypeError}} exception.
-    1.  Otherwise:
-        1.  Assert: |jsView| is a {{DataView}}.
-        1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsView|, Unordered).
-        1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, throw a {{TypeError}} exception.
+    1.  If [$IsArrayBufferViewOutOfBounds$](|jsView|) is true, throw a {{TypeError}} exception.
     1.  Return |jsView|.\[[ByteOffset]].
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -9323,10 +9323,10 @@ a reference to the same object that the IDL value represents.
 
         <p class="note">This step is not strictly necessary, since [=the range=] below is empty
         when |length| is 0. It is spelled out as a fast path for implementations.
-    1.  [=/Assert=]: |arrayBuffer| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
+    1.  Assert: |arrayBuffer| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
-    1.  [=/Assert=]: [$IsDetachedBuffer$](|jsArrayBuffer|) is false.
+    1.  Assert: [$IsDetachedBuffer$](|jsArrayBuffer|) is false.
     1.  Let |bytes| be a new [=byte sequence=] of [=byte sequence/length=] equal to |length|.
     1.  For |i| in [=the exclusive range|the range=] |offset| to |offset| + |length|, exclusive,
         set |bytes|[|i| &minus; |offset|] to [$GetValueFromBuffer$](|jsArrayBuffer|, |i|, Uint8,
@@ -9426,7 +9426,7 @@ a reference to the same object that the IDL value represents.
     <dfn id=arraybuffer-write-startingoffset export for="ArrayBuffer/write,SharedArrayBuffer/write">|startingOffset|</dfn>
     (default 0):
 
-    1.  [=/Assert=]: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=byte length=]
+    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=byte length=]
         &minus; |startingOffset|.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
@@ -9441,8 +9441,8 @@ a reference to the same object that the IDL value represents.
     {{ArrayBufferView}} |view|, optionally given a
     <dfn export for="ArrayBufferView/write">|startingOffset|</dfn> (default 0):
 
-    1.  [=/Assert=]: |view| is not [=ArrayBufferView/out of bounds=].
-    1.  [=/Assert=]: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=BufferSource/byte length=]
+    1.  Assert: |view| is not [=ArrayBufferView/out of bounds=].
+    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=BufferSource/byte length=]
         &minus; |startingOffset|.
     1.  Assert: if |view| is not a {{DataView}}, then |bytes|'s [=byte sequence/length=] [=modulo=]
         the [=element size=] of |view|'s type is 0.

--- a/index.bs
+++ b/index.bs
@@ -9316,15 +9316,13 @@ a reference to the same object that the IDL value represents.
         |bufferSource| to a JavaScript value.
     1.  Let |jsArrayBuffer| be |jsBufferSource|.
     1.  Let |offset| be 0.
-    1.  Let |length| be 0.
     1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=], then:
         1.  Set |jsArrayBuffer| to |jsBufferSource|.\[[ViewedArrayBuffer]].
-        1.  Set |offset| to |jsBufferSource|.\[[ByteOffset]].
-        1.  Set |length| to |jsBufferSource|.\[[ByteLength]].
+        1.  Set |offset| to |jsBufferSource|'s [=ArrayBufferView/byte offset=].
     1.  Otherwise:
         1.  Assert: |jsBufferSource| is an {{ArrayBuffer}} or
             {{SharedArrayBuffer}} object.
-        1.  Set |length| to |jsBufferSource|.\[[ArrayBufferByteLength]].
+    1.  Let |length| be |jsBufferSource|'s [=BufferSource/byte length=].
     1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then return the empty
         [=byte sequence=].
     1.  Let |bytes| be a new [=byte sequence=] of [=byte sequence/length=] equal to |length|.
@@ -9332,6 +9330,23 @@ a reference to the same object that the IDL value represents.
         set |bytes|[|i| &minus; |offset|] to [$GetValueFromBuffer$](|jsArrayBuffer|, |i|, Uint8,
         true, Unordered).
     1.  Return |bytes|.
+</div>
+
+<div algorithm>
+    The <dfn export for="ArrayBufferView">byte offset</dfn> of an {{ArrayBufferView}}
+    |view| is the value returned by the following steps:
+
+    1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=] |view| to
+        a JavaScript value.
+    1.  If |jsView| has a \[[TypedArrayName]] [=/internal slot=]:
+        1.  Assert: |jsView| is a [=typed array type=] instance.
+        1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsView|, Unordered).
+        1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, throw a {{TypeError}} exception.
+    1.  Otherwise:
+        1.  Assert: |jsView| is a {{DataView}}.
+        1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsView|, Unordered).
+        1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, throw a {{TypeError}} exception.
+    1.  Return |jsView|.\[[ByteOffset]].
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -9340,9 +9340,24 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsBufferSource| be the result of [=converted to a JavaScript value|converting=]
         |bufferSource| to a JavaScript value.
-    1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] internal slot, then return
-        |jsBufferSource|.\[[ByteLength]].
-    1.  Return |jsBufferSource|.\[[ArrayBufferByteLength]].
+    1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=], then:
+        1.  If |jsBufferSource| has a \[[TypedArrayName]] [=/internal slot=]:
+            1.  Assert: |jsBufferSource| is a [=typed array type=] instance.
+            1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|,
+                Unordered).
+            1.  Return [$TypedArrayByteLength$](|taRecord|).
+        1.  Otherwise:
+            1.  Assert: |jsBufferSource| is a {{DataView}}.
+            1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|,
+                Unordered).
+            1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, return 0.
+            1.  Return [$GetViewByteLength$](|viewRecord|).
+    1.  Otherwise, if [$IsSharedArrayBuffer$](|jsBufferSource|) is true, then:
+        1.  Assert: |jsBufferSource| is a {{SharedArrayBuffer}}.
+        1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Unordered).
+    1.  Otherwise:
+        1.  Assert: |jsBufferSource| is an {{ArrayBuffer}}.
+        1.  Return |jsBufferSource|.\[[ArrayBufferByteLength]].
 </div>
 <!-- TODO: should this be stricter around not being detached? -->
 

--- a/index.bs
+++ b/index.bs
@@ -9318,7 +9318,7 @@ a reference to the same object that the IDL value represents.
     1.  If |bufferSource| is a [=buffer view type=] instance:
         1.  Set |arrayBuffer| to |bufferSource|'s [=underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
-    1.  Assert: |arrayBuffer| is an {{ArrayBuffer}} or {{SharedArrayBuffer}} object.
+    1.  [=/Assert=]: |arrayBuffer| is an {{ArrayBuffer}} or {{SharedArrayBuffer}} object.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
     1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then return the empty
@@ -9348,21 +9348,21 @@ a reference to the same object that the IDL value represents.
         |bufferSource| to a JavaScript value.
     1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=]:
         1.  If |jsBufferSource| has a \[[TypedArrayName]] [=/internal slot=]:
-            1.  Assert: |jsBufferSource| is a [=typed array type=] instance.
+            1.  [=/Assert=]: |jsBufferSource| is a [=typed array type=] instance.
             1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|,
                 Seq-Cst).
             1.  Return [$TypedArrayByteLength$](|taRecord|).
         1.  Otherwise:
-            1.  Assert: |jsBufferSource| is a {{DataView}}.
+            1.  [=/Assert=]: |jsBufferSource| is a {{DataView}}.
             1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|,
                 Seq-Cst).
             1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then return 0.
             1.  Return [$GetViewByteLength$](|viewRecord|).
     1.  Otherwise, if [$IsSharedArrayBuffer$](|jsBufferSource|) is true:
-        1.  Assert: |jsBufferSource| is a {{SharedArrayBuffer}}.
+        1.  [=/Assert=]: |jsBufferSource| is a {{SharedArrayBuffer}}.
         1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
     1.  Otherwise:
-        1.  Assert: |jsBufferSource| is an {{ArrayBuffer}}.
+        1.  [=/Assert=]: |jsBufferSource| is an {{ArrayBuffer}}.
         1.  Return |jsBufferSource|.\[[ArrayBufferByteLength]].
 </div>
 <!-- TODO: should this be stricter around not being detached? -->
@@ -9387,7 +9387,7 @@ a reference to the same object that the IDL value represents.
     <dfn id=arraybuffer-write-startingoffset export for="ArrayBuffer/write,SharedArrayBuffer/write">|startingOffset|</dfn>
     (default 0):
 
-    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=byte length=]
+    1.  [=/Assert=]: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=byte length=]
         &minus; |startingOffset|.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
@@ -9402,7 +9402,7 @@ a reference to the same object that the IDL value represents.
     {{ArrayBufferView}} |view|, optionally given a
     <dfn export for="ArrayBufferView/write">|startingOffset|</dfn> (default 0):
 
-    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=byte length=] &minus;
+    1.  [=/Assert=]: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=byte length=] &minus;
         |startingOffset|.
     1.  Assert: if |view| is not a {{DataView}}, then |bytes|'s [=byte sequence/length=] [=modulo=]
         the [=element size=] of |view|'s type is 0.

--- a/index.bs
+++ b/index.bs
@@ -9371,31 +9371,27 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsBufferSource| be the result of [=converted to a JavaScript value|converting=]
         |bufferSource| to a JavaScript value.
-    1.  If |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=]:
-        1.  If |jsBufferSource| has a \[[TypedArrayName]] [=/internal slot=]:
-            1.  [=/Assert=]: |jsBufferSource| is a [=typed array type=] instance.
-            1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|,
-                Seq-Cst).
-            1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, then return 0.
-            1.  Return [$TypedArrayByteLength$](|taRecord|).
-                <p class="note">The above substeps are equivalent to
-                {{%TypedArray%/byteLength|%TypedArray%.prototype.byteLength}}.
-        1.  Otherwise:
-            1.  [=/Assert=]: |jsBufferSource| is a {{DataView}}.
-            1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|,
-                Seq-Cst).
-            1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then [=JavaScript/throw=] a
-                <l spec=ecmascript>{{TypeError}}</l>.
-            1.  Return [$GetViewByteLength$](|viewRecord|).
-                <p class="note">The above substeps are equivalent to
-                {{DataView/byteLength|DataView.prototype.byteLength}}.
+    1.  If |jsBufferSource| has a \[[DataView]] [=/internal slot=]:
+        1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|, Seq-Cst).
+        1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then [=JavaScript/throw=] a
+            <l spec=ecmascript>{{TypeError}}</l>.
+        1.  Return [$GetViewByteLength$](|viewRecord|).
+    1.  Otherwise, if |jsBufferSource| has a \[[ViewedArrayBuffer]] [=/internal slot=]:
+        1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsBufferSource|, Seq-Cst).
+        1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, then return 0.
+        1.  Return [$TypedArrayByteLength$](|taRecord|).
     1.  Otherwise:
-        1.  [=/Assert=]: |jsBufferSource| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
+        1.  Assert: |jsBufferSource| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
         1.  If [$IsDetachedBuffer$](|jsBufferSource|) is true, then return 0.
         1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
-            <p class="note">The above substeps are equivalent to
-            {{ArrayBuffer/byteLength|ArrayBuffer.prototype.byteLength}} or
-            {{SharedArrayBuffer/byteLength|SharedArrayBuffer.prototype.byteLength}}.
+
+    <p class="note">These steps are equivalent to
+    {{%TypedArray%/byteLength|%TypedArray%.prototype.byteLength}} (for a
+    [=typed array type=] instance), {{DataView/byteLength|DataView.prototype.byteLength}}
+    (for a {{DataView}}), or
+    {{ArrayBuffer/byteLength|ArrayBuffer.prototype.byteLength}} and
+    {{SharedArrayBuffer/byteLength|SharedArrayBuffer.prototype.byteLength}}
+    (for a [=buffer type=] instance).
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -9335,9 +9335,10 @@ a reference to the same object that the IDL value represents.
     The <dfn export for="ArrayBufferView">byte offset</dfn> of an {{ArrayBufferView}}
     |view| is the value returned by the following steps:
 
+    1.  If |view| is [=ArrayBufferView/out of bounds=], then [=JavaScript/throw=] a
+        <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=] |view| to
         a JavaScript value.
-    1.  If [$IsArrayBufferViewOutOfBounds$](|jsView|) is true, then throw a {{TypeError}} exception.
     1.  Return |jsView|.\[[ByteOffset]].
 </div>
 
@@ -9367,6 +9368,15 @@ a reference to the same object that the IDL value represents.
         1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
 </div>
 <!-- TODO: should this be stricter around not being detached? -->
+
+<div algorithm>
+    An {{ArrayBufferView}} |view| is <dfn export for="ArrayBufferView">out of bounds</dfn>
+    if the following steps return true:
+
+    1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=]
+        |view| to a JavaScript value.
+    1.  Return [$IsArrayBufferViewOutOfBounds$](|jsView|).
+</div>
 
 <div algorithm>
     The <dfn export for="BufferSource">underlying buffer</dfn> of a [=buffer source type=] instance

--- a/index.bs
+++ b/index.bs
@@ -9474,22 +9474,20 @@ a reference to the same object that the IDL value represents.
     1.  Return true.
 </div>
 
-<div algorithm>
+<div algorithm="ArrayBuffer/transfer">
     To <dfn for="ArrayBuffer" export>transfer</dfn> an {{ArrayBuffer}} |arrayBuffer|, optionally
-    given a [=realm=] |targetRealm|:
+    given <dfn export for="ArrayBuffer/transfer">|preserveResizability|</dfn> (default false):
 
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
     1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then [=JavaScript/throw=] a
         <l spec=ecmascript>{{TypeError}}</l>.
-    1.  Let |arrayBufferData| be |jsArrayBuffer|.\[[ArrayBufferData]].
-    1.  Let |arrayBufferByteLength| be |jsArrayBuffer|.\[[ArrayBufferByteLength]].
-    1.  Perform [=?=] [$DetachArrayBuffer$](|jsArrayBuffer|).
-    1.  If |targetRealm| is not given, let |targetRealm| be the [=current realm=].
-    1.  Let |jsTransferred| be [=?=]
-        [$AllocateArrayBuffer$](|targetRealm|.\[[Intrinsics]].\[[{{%ArrayBuffer%}}]], 0).
-    1.  Set |jsTransferred|.\[[ArrayBufferData]] to |arrayBufferData|.
-    1.  Set |jsTransferred|.\[[ArrayBufferByteLength]] to |arrayBufferByteLength|.
+    1.  If |preserveResizability| is true, then:
+        1.  Let |jsTransferred| be [=?=] [$ArrayBufferCopyAndDetach$](|jsArrayBuffer|, undefined,
+            Preserve-Resizability).
+    1.  Otherwise,
+        1.  Let |jsTransferred| be [=?=] [$ArrayBufferCopyAndDetach$](|jsArrayBuffer|, undefined,
+            Fixed-Length).
     1.  Return the result of [=converted to an IDL value|converting=] |jsTransferred| to an IDL
         value of type {{ArrayBuffer}}.
 

--- a/index.bs
+++ b/index.bs
@@ -9398,7 +9398,7 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
-    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |jsArrayBuffer|.\[[ArrayBufferByteLength]]
+    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=byte length=]
         &minus; |startingOffset|.
     1.  For |i| in [=the exclusive range|the range=] |startingOffset| to |startingOffset| +
         |bytes|'s [=byte sequence/length=], exclusive, perform
@@ -9411,15 +9411,12 @@ a reference to the same object that the IDL value represents.
     {{ArrayBufferView}} |view|, optionally given a
     <dfn export for="ArrayBufferView/write">|startingOffset|</dfn> (default 0):
 
-    1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=] |view| to
-        a JavaScript value.
-    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |jsView|.\[[ByteLength]] &minus;
+    1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=byte length=] &minus;
         |startingOffset|.
     1.  Assert: if |view| is not a {{DataView}}, then |bytes|'s [=byte sequence/length=] [=modulo=]
         the [=element size=] of |view|'s type is 0.
-    1.  Let |arrayBuffer| be |view|'s [=underlying buffer=].
-    1.  [=ArrayBuffer/Write=] |bytes| into |arrayBuffer| with
-        <i>[=ArrayBuffer/write/startingOffset=]</i> set to |jsView|.\[[ByteOffset]] +
+    1.  [=ArrayBuffer/Write=] |bytes| into |view|'s [=underlying buffer=] with
+        <i>[=ArrayBuffer/write/startingOffset=]</i> set to |view|'s [=ArrayBufferView/byte offset=] +
         |startingOffset|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -9396,10 +9396,10 @@ a reference to the same object that the IDL value represents.
     <dfn id=arraybuffer-write-startingoffset export for="ArrayBuffer/write,SharedArrayBuffer/write">|startingOffset|</dfn>
     (default 0):
 
-    1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
-        |arrayBuffer| to a JavaScript value.
     1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |arrayBuffer|'s [=byte length=]
         &minus; |startingOffset|.
+    1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
+        |arrayBuffer| to a JavaScript value.
     1.  For |i| in [=the exclusive range|the range=] |startingOffset| to |startingOffset| +
         |bytes|'s [=byte sequence/length=], exclusive, perform
         [$SetValueInBuffer$](|jsArrayBuffer|, |i|, Uint8, |bytes|[|i| - |startingOffset|], true,

--- a/index.bs
+++ b/index.bs
@@ -9417,8 +9417,7 @@ a reference to the same object that the IDL value represents.
         |startingOffset|.
     1.  Assert: if |view| is not a {{DataView}}, then |bytes|'s [=byte sequence/length=] [=modulo=]
         the [=element size=] of |view|'s type is 0.
-    1.  Let |arrayBuffer| be the result of [=converted to an IDL value|converting=]
-        |jsView|.\[[ViewedArrayBuffer]] to an IDL value of type {{ArrayBuffer}}.
+    1.  Let |arrayBuffer| be |view|'s [=underlying buffer=].
     1.  [=ArrayBuffer/Write=] |bytes| into |arrayBuffer| with
         <i>[=ArrayBuffer/write/startingOffset=]</i> set to |jsView|.\[[ByteOffset]] +
         |startingOffset|.

--- a/index.bs
+++ b/index.bs
@@ -9314,12 +9314,14 @@ a reference to the same object that the IDL value represents.
 
     1.  If |bufferSource| is [=BufferSource/detached=], then return the empty [=byte sequence=].
     1.  Let |length| be |bufferSource|'s [=BufferSource/byte length=].
-    1.  If |length| is 0, then return the empty [=byte sequence=].
     1.  Let |arrayBuffer| be |bufferSource|.
     1.  Let |offset| be 0.
     1.  If |bufferSource| is a [=buffer view type=] instance:
         1.  Set |arrayBuffer| to |bufferSource|'s [=underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].
+            <p class="note">This will throw an exception if |bufferSource| is
+            [=ArrayBufferView/out of bounds=].
+    1.  If |length| is 0, then return the empty [=byte sequence=].
     1.  [=/Assert=]: |arrayBuffer| is an {{ArrayBuffer}} or {{SharedArrayBuffer}} object.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.

--- a/index.bs
+++ b/index.bs
@@ -9346,16 +9346,23 @@ a reference to the same object that the IDL value represents.
     The <dfn export for="ArrayBufferView">byte offset</dfn> of an {{ArrayBufferView}}
     |view| is the value returned by the following steps:
 
-    1.  If |view| is [=ArrayBufferView/out of bounds=], then [=JavaScript/throw=] a
-        <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=] |view| to
         a JavaScript value.
+    1.  If |jsView| has a \[[DataView]] [=/internal slot=]:
+        1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsView|, Seq-Cst).
+        1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then [=JavaScript/throw=] a
+            <l spec=ecmascript>{{TypeError}}</l>.
+    1.  Otherwise:
+        1.  Let |taRecord| be [$MakeTypedArrayWithBufferWitnessRecord$](|jsView|, Seq-Cst).
+        1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, then return 0.
     1.  Return |jsView|.\[[ByteOffset]].
 
     <p class="note">These steps are equivalent to
     {{%TypedArray%/byteOffset|%TypedArray%.prototype.byteOffset}} (for a
     [=typed array type=] instance) or {{DataView/byteOffset|DataView.prototype.byteOffset}}
-    (for a {{DataView}}).
+    (for a {{DataView}}). In particular, this deliberately mirrors JavaScript's asymmetry: a
+    [=typed array type=] instance that is [=ArrayBufferView/out of bounds=] has a byte offset of
+    0, whereas a {{DataView}} that is [=ArrayBufferView/out of bounds=] instead throws.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -9442,6 +9442,7 @@ a reference to the same object that the IDL value represents.
     <dfn export for="ArrayBufferView/write">|startingOffset|</dfn> (default 0):
 
     1.  Assert: |view| is not [=ArrayBufferView/out of bounds=].
+        <p class="note">This implies that |view| is not [=BufferSource/detached=].
     1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=BufferSource/byte length=]
         &minus; |startingOffset|.
     1.  Assert: if |view| is not a {{DataView}}, then |bytes|'s [=byte sequence/length=] [=modulo=]
@@ -9449,11 +9450,6 @@ a reference to the same object that the IDL value represents.
     1.  [=ArrayBuffer/Write=] |bytes| into |view|'s [=BufferSource/underlying buffer=] with
         <i>[=ArrayBuffer/write/startingOffset=]</i> set to
         |view|'s [=ArrayBufferView/byte offset=] + |startingOffset|.
-
-    <p class="note">Callers must ensure that |view| is not [=ArrayBufferView/out of bounds=],
-    which also means that it is not [=BufferSource/detached=]. Otherwise, |view|'s
-    [=BufferSource/byte length=] and [=ArrayBufferView/byte offset=] could throw an exception,
-    and assertions must not be observable.
 </div>
 
 <div class="warning">

--- a/index.bs
+++ b/index.bs
@@ -9342,6 +9342,11 @@ a reference to the same object that the IDL value represents.
     1.  Let |jsView| be the result of [=converted to a JavaScript value|converting=] |view| to
         a JavaScript value.
     1.  Return |jsView|.\[[ByteOffset]].
+
+    <p class="note">These steps are equivalent to
+    {{%TypedArray%/byteOffset|%TypedArray%.prototype.byteOffset}} (for a
+    [=typed array type=] instance) or {{DataView/byteOffset|DataView.prototype.byteOffset}}
+    (for a {{DataView}}).
 </div>
 
 <div algorithm>
@@ -9357,6 +9362,8 @@ a reference to the same object that the IDL value represents.
                 Seq-Cst).
             1.  If [$IsTypedArrayOutOfBounds$](|taRecord|) is true, then return 0.
             1.  Return [$TypedArrayByteLength$](|taRecord|).
+                <p class="note">The above substeps are equivalent to
+                {{%TypedArray%/byteLength|%TypedArray%.prototype.byteLength}}.
         1.  Otherwise:
             1.  [=/Assert=]: |jsBufferSource| is a {{DataView}}.
             1.  Let |viewRecord| be [$MakeDataViewWithBufferWitnessRecord$](|jsBufferSource|,
@@ -9364,10 +9371,15 @@ a reference to the same object that the IDL value represents.
             1.  If [$IsViewOutOfBounds$](|viewRecord|) is true, then [=JavaScript/throw=] a
                 <l spec=ecmascript>{{TypeError}}</l>.
             1.  Return [$GetViewByteLength$](|viewRecord|).
+                <p class="note">The above substeps are equivalent to
+                {{DataView/byteLength|DataView.prototype.byteLength}}.
     1.  Otherwise:
         1.  [=/Assert=]: |jsBufferSource| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
         1.  If [$IsDetachedBuffer$](|jsBufferSource|) is true, then return 0.
         1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
+            <p class="note">The above substeps are equivalent to
+            {{ArrayBuffer/byteLength|ArrayBuffer.prototype.byteLength}} or
+            {{SharedArrayBuffer/byteLength|SharedArrayBuffer.prototype.byteLength}}.
 </div>
 <!-- TODO: should this be stricter around not being detached? -->
 

--- a/index.bs
+++ b/index.bs
@@ -9442,6 +9442,7 @@ a reference to the same object that the IDL value represents.
     <dfn export for="ArrayBufferView/write">|startingOffset|</dfn> (default 0):
 
     1.  Assert: |view| is not [=ArrayBufferView/out of bounds=].
+
         <p class="note">This implies that |view| is not [=BufferSource/detached=].
     1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |view|'s [=BufferSource/byte length=]
         &minus; |startingOffset|.

--- a/index.bs
+++ b/index.bs
@@ -9381,7 +9381,6 @@ a reference to the same object that the IDL value represents.
             {{ArrayBuffer/byteLength|ArrayBuffer.prototype.byteLength}} or
             {{SharedArrayBuffer/byteLength|SharedArrayBuffer.prototype.byteLength}}.
 </div>
-<!-- TODO: should this be stricter around not being detached? -->
 
 <div algorithm>
     An {{ArrayBufferView}} |view| is <dfn export for="ArrayBufferView">out of bounds</dfn>

--- a/index.bs
+++ b/index.bs
@@ -9312,6 +9312,7 @@ a reference to the same object that the IDL value represents.
     To <dfn id="dfn-get-buffer-source-copy" export lt="get a copy of the buffer source|get a copy of the bytes held by the buffer source">get a copy of the bytes held by the buffer source</dfn>
     given a [=buffer source type=] instance |bufferSource|:
 
+    1.  If |bufferSource| is [=BufferSource/detached=], then return the empty [=byte sequence=].
     1.  Let |arrayBuffer| be |bufferSource|.
     1.  Let |offset| be 0.
     1.  Let |length| be |bufferSource|'s [=BufferSource/byte length=].
@@ -9321,8 +9322,7 @@ a reference to the same object that the IDL value represents.
     1.  [=/Assert=]: |arrayBuffer| is an {{ArrayBuffer}} or {{SharedArrayBuffer}} object.
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
-    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then return the empty
-        [=byte sequence=].
+    1.  [=/Assert=]: [$IsDetachedBuffer$](|jsArrayBuffer|) is false.
     1.  Let |bytes| be a new [=byte sequence=] of [=byte sequence/length=] equal to |length|.
     1.  For |i| in [=the exclusive range|the range=] |offset| to |offset| + |length|, exclusive,
         set |bytes|[|i| &minus; |offset|] to [$GetValueFromBuffer$](|jsArrayBuffer|, |i|, Uint8,
@@ -9362,6 +9362,7 @@ a reference to the same object that the IDL value represents.
             1.  Return [$GetViewByteLength$](|viewRecord|).
     1.  Otherwise:
         1.  [=/Assert=]: |jsBufferSource| is an {{ArrayBuffer}} or a {{SharedArrayBuffer}}.
+        1.  If [$IsDetachedBuffer$](|jsBufferSource|) is true, then return 0.
         1.  Return [$ArrayBufferByteLength$](|jsBufferSource|, Seq-Cst).
 </div>
 <!-- TODO: should this be stricter around not being detached? -->

--- a/index.bs
+++ b/index.bs
@@ -9313,10 +9313,10 @@ a reference to the same object that the IDL value represents.
     given a [=buffer source type=] instance |bufferSource|:
 
     1.  If |bufferSource| is [=BufferSource/detached=], then return the empty [=byte sequence=].
-    1.  Let |arrayBuffer| be |bufferSource|.
-    1.  Let |offset| be 0.
     1.  Let |length| be |bufferSource|'s [=BufferSource/byte length=].
     1.  If |length| is 0, then return the empty [=byte sequence=].
+    1.  Let |arrayBuffer| be |bufferSource|.
+    1.  Let |offset| be 0.
     1.  If |bufferSource| is a [=buffer view type=] instance:
         1.  Set |arrayBuffer| to |bufferSource|'s [=underlying buffer=].
         1.  Set |offset| to |bufferSource|'s [=ArrayBufferView/byte offset=].


### PR DESCRIPTION
Previously, many `BufferSource` algorithms were using internal slots such as `[[ByteOffset]]` and `[[ByteLength]]` directly. However, with the addition of `SharedArrayBuffer` (#353, #1311) and `[AllowResizable]` (#982), this comes with extra caveats:
* To get the byte length of a `SharedArrayBuffer`, we need to use [`ArrayBufferByteLength`](https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybufferbytelength) to match [`SharedArrayBuffer.prototype.byteLength`](https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.bytelength).
* To get the byte length of a ["length-tracking" typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#behavior_when_viewing_a_resizable_buffer), we need to use [`TypedArrayByteLength`](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-typedarraybytelength). Similarly, for a length-tracking `DataView`, we need to use [`GetViewByteLength`](https://tc39.es/ecma262/multipage/structured-data.html#sec-getviewbytelength).
* To get the byte offset of a typed array or `DataView`, we first need to check whether the view is still in bounds using [`IsArrayBufferViewOutOfBounds`](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-isarraybufferviewoutofbounds).

"Byte length" and "byte offset" both mirror JavaScript's asymmetry between typed arrays and `DataView`s: an out-of-bounds typed array reports 0, whereas an out-of-bounds `DataView` throws a `TypeError`. That way, implementations can reuse their existing getters.

When reading the length of a buffer, we use `SEQ-CST` ordering to match ECMAScript. When reading the *contents* of a buffer, we keep using `UNORDERED`, as "get a copy of the bytes held by the buffer source" already did. See https://github.com/whatwg/webidl/pull/1529#issuecomment-3757018345.

Transferring an `ArrayBuffer` must also take into account whether it should remain resizable or not. Fortunately, we can use the new [`ArrayBufferCopyAndDetach`](https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffercopyanddetach) operation for that.
* I added an optional `preserveResizability` parameter to "transfer an `ArrayBuffer`", so specifications can choose whether to preserve resizability or not. By default, this is not preserved. I intend to use it in Streams, see https://github.com/whatwg/streams/pull/1360.
* I removed the `realm` parameter of that algorithm, since `ArrayBufferCopyAndDetach` doesn't accept such a parameter. [According to WebDex](https://dontcallmedom.github.io/webdex/t.html#transfer%40%40ArrayBuffer%40dfn), no specs were actually using that parameter anyway.

Normative changes, which need a review of existing callers:
* "Byte length" now throws a `TypeError` for a `DataView` that is detached or out of bounds, where it previously returned a stale `[[ByteLength]]`. This is reachable without `[AllowResizable]`, simply by detaching the underlying buffer. "Get a copy of the bytes held by the buffer source" inherits this. Both algorithms have a note documenting it, but every existing caller is currently written as an infallible read.
* "Transfer" no longer takes a `realm` parameter. Per WebDex this is not a breaking change in practice, but it does change the exported signature.
* "Transfer" on a resizable `ArrayBuffer` now yields a fixed-length `ArrayBuffer` by default, instead of reusing the original buffer's resizability.

Relates to #1312.
Fixes #1385.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62301
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1529.html" title="Last updated on Aug 29, 2026, 2:41 PM UTC (aabd4f3)">Preview</a> | <a href="https://whatpr.org/webidl/1529/3c82f93...aabd4f3.html" title="Last updated on Aug 29, 2026, 2:41 PM UTC (aabd4f3)">Diff</a>