### PR TITLE
Propagate a type's extended attributes to a nullable inner type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6492,7 +6492,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
     an IDL type |type| are determined as follows:
 
     1.  Let |extended attributes| be a new empty [=ordered set|set=].
-    1.  If |type| appears as part of a
+    1.  If |type| is the <emu-nt><a href="#prod-Type">Type</a></emu-nt> directly within a
         <emu-nt><a href="#prod-TypeWithExtendedAttributes">TypeWithExtendedAttributes</a></emu-nt>
         production, [=set/append=] each of the [=extended attributes=] present in the production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> to
@@ -6536,10 +6536,9 @@ The following extended attributes are <dfn for="extended attributes">applicable 
                 };
             </pre>
         </div>
-    1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
-        directly within an <emu-nt><a href="#prod-Argument">Argument</a></emu-nt> production,
-        [=set/append=] to |extended attributes| all of the [=extended attributes=] present in the
-        production's
+    1.  If |type| is the <emu-nt><a href="#prod-Type">Type</a></emu-nt> directly within an
+        <emu-nt><a href="#prod-Argument">Argument</a></emu-nt> production, [=set/append=] to
+        |extended attributes| all of the [=extended attributes=] present in the production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
         [=applicable to types=].
 
@@ -6555,10 +6554,10 @@ The following extended attributes are <dfn for="extended attributes">applicable 
             [=applicable to types=]; otherwise [<code>XAttr</code>] applies to the argument, and not
             the argument's type.
         </div>
-    1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
-        directly within a <emu-nt><a href="#prod-DictionaryMember">DictionaryMember</a></emu-nt>
-        production, [=set/append=] to |extended attributes| all of the [=extended attributes=]
-        present in the production's
+    1.  If |type| is the <emu-nt><a href="#prod-Type">Type</a></emu-nt> directly within a
+        <emu-nt><a href="#prod-DictionaryMember">DictionaryMember</a></emu-nt> production,
+        [=set/append=] to |extended attributes| all of the [=extended attributes=] present in the
+        production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
         [=applicable to types=].
 

--- a/index.bs
+++ b/index.bs
@@ -6522,6 +6522,17 @@ The following extended attributes are <dfn for="extended attributes">applicable 
                 };
             </pre>
         </div>
+    1.  If |type| is the [=nullable types/inner type=] of a [=nullable type=] |N|, [=set/append=]
+        each of the [=extended attributes associated with=] |N| to |extended attributes|.
+
+        <div class="example" id="example-5feb96ff">
+            <pre class="idl">
+                [Exposed=Window]
+                interface I {
+                    undefined f([Clamp] long? arg);
+                };
+            </pre>
+        </div>
     1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
         directly within an <emu-nt><a href="#prod-Argument">Argument</a></emu-nt> production,
         [=set/append=] to |extended attributes| all of the [=extended attributes=] present in the
@@ -9578,7 +9589,8 @@ that is growable.
 
 The [{{AllowResizable}}] extended attribute must [=takes no arguments|take no arguments=].
 
-A type that is not a [=buffer source type=] must not be
+A type that is not a [=buffer source type=], and that is not a [=nullable type=] whose
+[=nullable types/inner type=] is a [=buffer source type=], must not be
 [=extended attributes associated with|associated with=] the [{{AllowResizable}}] extended attribute.
 
 See the rules for converting JavaScript values to IDL [=buffer source types=] in
@@ -9595,7 +9607,8 @@ only by an {{ArrayBuffer}}.
 
 The [{{AllowShared}}] extended attribute must [=takes no arguments|take no arguments=].
 
-A type that is not a [=buffer view type=] must not be
+A type that is not a [=buffer view type=], and that is not a [=nullable type=] whose
+[=nullable types/inner type=] is a [=buffer view type=], must not be
 [=extended attributes associated with|associated with=] the [{{AllowShared}}] extended attribute.
 
 See the rules for converting JavaScript values to IDL [=buffer view types=] in
@@ -9654,7 +9667,8 @@ extended attribute must
 
 A type annotated with the [{{Clamp}}] extended attribute must not appear in a [=read only=]
 attribute. A type must not be [=extended attributes associated with|associated with=] both the
-[{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not an [=integer type=] must
+[{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not an [=integer type=], and
+that is not a [=nullable type=] whose [=nullable types/inner type=] is an [=integer type=], must
 not be [=extended attributes associated with|associated with=] the [{{Clamp}}] extended attribute.
 
 See the rules for converting JavaScript values to the various IDL integer
@@ -9868,7 +9882,8 @@ extended attribute must
 A type annotated with the [{{EnforceRange}}] extended attribute must not appear in a
 [=read only=] attribute. A type must not be [=extended attributes associated with|associated with=]
 both the [{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not an
-[=integer type=] must not be [=extended attributes associated with|associated with=] the
+[=integer type=], and that is not a [=nullable type=] whose [=nullable types/inner type=] is an
+[=integer type=], must not be [=extended attributes associated with|associated with=] the
 [{{EnforceRange}}] extended attribute.
 
 See the rules for converting JavaScript values to the various IDL integer
@@ -11094,7 +11109,8 @@ The [{{LegacyNullToEmptyString}}] extended attribute must not be
 [=extended attribute associated with|associated with=] a type that is not {{DOMString}} or {{USVString}}.
 
 Note: This means that even <code class="idl">DOMString?</code> must not use [{{LegacyNullToEmptyString}}], since
-<emu-val>null</emu-val> is a valid value of that type.
+<emu-val>null</emu-val> is a valid value of that type. Unlike other [=extended attributes=] that
+are [=applicable to types=], [{{LegacyNullToEmptyString}}] may not be used on a [=nullable type=].
 
 See [[#js-DOMString]] for the specific requirements that the use of [{{LegacyNullToEmptyString}}] entails.
 

--- a/index.bs
+++ b/index.bs
@@ -6525,7 +6525,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
     1.  If |type| is the [=nullable types/inner type=] of a [=nullable type=] |N|, [=set/append=]
         each of the [=extended attributes associated with=] |N| to |extended attributes|.
 
-        <div class="example" id="example-5feb96ff">
+        <div class="example" id="example-extended-attribute-association-nullable">
             <pre class="idl">
                 [Exposed=Window]
                 interface I {

--- a/index.bs
+++ b/index.bs
@@ -6201,6 +6201,9 @@ The [=nullable types/inner type=] must not be:
 Note: Although dictionary types can in general be nullable,
 they cannot when used as the type of an operation argument or a dictionary member.
 
+For any type |X|, a <dfn>potentially nullable</dfn> |X| is either an |X| or a
+[=nullable type=] whose [=nullable types/inner type=] is an |X|.
+
 Nullable type constant values in IDL are represented in the same way that
 constant values of their [=nullable types/inner type=]
 would be represented, or with the <emu-t>null</emu-t> token.
@@ -9573,24 +9576,25 @@ whose presence affects the JavaScript binding.
 
 <h4 id="AllowResizable" extended-attribute lt="AllowResizable">[AllowResizable]</h4>
 
-If the [{{AllowResizable}}] [=extended attribute=] appears on a [=buffer type=], it creates a new
-IDL type that allows for the respective corresponding JavaScript <l spec=ecmascript>{{ArrayBuffer}}</l>
-or <l spec=ecmascript>{{SharedArrayBuffer}}</l> object to be resizable.
+If the [{{AllowResizable}}] [=extended attribute=] appears on a [=potentially nullable=]
+[=buffer type=], it creates a new IDL type that allows for the respective corresponding JavaScript
+<l spec=ecmascript>{{ArrayBuffer}}</l> or <l spec=ecmascript>{{SharedArrayBuffer}}</l> object to be
+resizable.
 
-If the [{{AllowResizable}}] [=extended attribute=] appears on one of the [=buffer view types=] and
-the [{{AllowShared}}] [=extended attribute=] does not, it creates a new IDL type that allows the
-buffer view type to be backed by a JavaScript <l spec=ecmascript>{{ArrayBuffer}}</l> that is
-resizable, instead of only by a fixed-length <l spec=ecmascript>{{ArrayBuffer}}</l>.
+If the [{{AllowResizable}}] [=extended attribute=] appears on a [=potentially nullable=]
+[=buffer view type=] and the [{{AllowShared}}] [=extended attribute=] does not, it creates a new
+IDL type that allows the buffer view type to be backed by a JavaScript
+<l spec=ecmascript>{{ArrayBuffer}}</l> that is resizable, instead of only by a fixed-length
+<l spec=ecmascript>{{ArrayBuffer}}</l>.
 
 If the [{{AllowResizable}}] [=extended attribute=] and the [{{AllowShared}}] [=extended attribute=]
-both appear on one of the [=buffer view types=], it creates a new IDL type that allows the buffer
-view type to be additionally backed by a JavaScript <l spec=ecmascript>{{SharedArrayBuffer}}</l>
-that is growable.
+both appear on a [=potentially nullable=] [=buffer view type=], it creates a new IDL type that
+allows the buffer view type to be additionally backed by a JavaScript
+<l spec=ecmascript>{{SharedArrayBuffer}}</l> that is growable.
 
 The [{{AllowResizable}}] extended attribute must [=takes no arguments|take no arguments=].
 
-A type that is not a [=buffer source type=], and that is not a [=nullable type=] whose
-[=nullable types/inner type=] is a [=buffer source type=], must not be
+A type that is not a [=potentially nullable=] [=buffer source type=] must not be
 [=extended attributes associated with|associated with=] the [{{AllowResizable}}] extended attribute.
 
 See the rules for converting JavaScript values to IDL [=buffer source types=] in
@@ -9601,14 +9605,13 @@ See the <a href="#example-allowresizable-allowshared">example</a> in [[#AllowSha
 
 <h4 id="AllowShared" extended-attribute lt="AllowShared">[AllowShared]</h4>
 
-If the [{{AllowShared}}] [=extended attribute=] appears on one of the [=buffer view types=], it
-creates a new IDL type that allows the object to be backed by an {{SharedArrayBuffer}} instead of
-only by an {{ArrayBuffer}}.
+If the [{{AllowShared}}] [=extended attribute=] appears on a [=potentially nullable=]
+[=buffer view type=], it creates a new IDL type that allows the object to be backed by an
+{{SharedArrayBuffer}} instead of only by an {{ArrayBuffer}}.
 
 The [{{AllowShared}}] extended attribute must [=takes no arguments|take no arguments=].
 
-A type that is not a [=buffer view type=], and that is not a [=nullable type=] whose
-[=nullable types/inner type=] is a [=buffer view type=], must not be
+A type that is not a [=potentially nullable=] [=buffer view type=] must not be
 [=extended attributes associated with|associated with=] the [{{AllowShared}}] extended attribute.
 
 See the rules for converting JavaScript values to IDL [=buffer view types=] in
@@ -9656,8 +9659,8 @@ See the rules for converting JavaScript values to IDL [=buffer view types=] in
 
 <h4 id="Clamp" extended-attribute lt="Clamp">[Clamp]</h4>
 
-If the [{{Clamp}}] [=extended attribute=] appears on one of the [=integer types=], it creates a new
-IDL type such that that when a JavaScript Number is converted to the IDL type,
+If the [{{Clamp}}] [=extended attribute=] appears on a [=potentially nullable=] [=integer type=],
+it creates a new IDL type such that when a JavaScript Number is converted to the IDL type,
 out-of-range values will be clamped to the range of valid values, rather than using the operators
 that use a modulo operation (<a abstract-op>ToInt32</a>, <a abstract-op>ToUint32</a>, etc.).
 
@@ -9667,9 +9670,9 @@ extended attribute must
 
 A type annotated with the [{{Clamp}}] extended attribute must not appear in a [=read only=]
 attribute. A type must not be [=extended attributes associated with|associated with=] both the
-[{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not an [=integer type=], and
-that is not a [=nullable type=] whose [=nullable types/inner type=] is an [=integer type=], must
-not be [=extended attributes associated with|associated with=] the [{{Clamp}}] extended attribute.
+[{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not a
+[=potentially nullable=] [=integer type=] must not be
+[=extended attributes associated with|associated with=] the [{{Clamp}}] extended attribute.
 
 See the rules for converting JavaScript values to the various IDL integer
 types in [[#js-integer-types]]
@@ -9869,10 +9872,11 @@ that [=has default method steps=] defined.
 
 <h4 id="EnforceRange" extended-attribute lt="EnforceRange">[EnforceRange]</h4>
 
-If the [{{EnforceRange}}] [=extended attribute=] appears on one of the [=integer types=], it creates
-a new IDL type such that that when a JavaScript Number is converted to the IDL
-type, out-of-range values will cause an exception to be thrown, rather than being converted to a
-valid value using using the operators that use a modulo operation (<a abstract-op>ToInt32</a>, <a abstract-op>ToUint32</a>, etc.).
+If the [{{EnforceRange}}] [=extended attribute=] appears on a [=potentially nullable=]
+[=integer type=], it creates a new IDL type such that when a JavaScript Number is converted to
+the IDL type, out-of-range values will cause an exception to be thrown, rather than being converted
+to a valid value using the operators that use a modulo operation
+(<a abstract-op>ToInt32</a>, <a abstract-op>ToUint32</a>, etc.).
 The Number will be rounded toward zero before being checked against its range.
 
 The [{{EnforceRange}}]
@@ -9881,10 +9885,9 @@ extended attribute must
 
 A type annotated with the [{{EnforceRange}}] extended attribute must not appear in a
 [=read only=] attribute. A type must not be [=extended attributes associated with|associated with=]
-both the [{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not an
-[=integer type=], and that is not a [=nullable type=] whose [=nullable types/inner type=] is an
-[=integer type=], must not be [=extended attributes associated with|associated with=] the
-[{{EnforceRange}}] extended attribute.
+both the [{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not a
+[=potentially nullable=] [=integer type=] must not be
+[=extended attributes associated with|associated with=] the [{{EnforceRange}}] extended attribute.
 
 See the rules for converting JavaScript values to the various IDL integer
 types in [[#js-type-mapping]]
@@ -11101,7 +11104,7 @@ for the specific requirements that the use of
 <h4 id="LegacyNullToEmptyString" extended-attribute lt="LegacyNullToEmptyString" oldids="TreatNullAs">[LegacyNullToEmptyString]</h4>
 
 If the [{{LegacyNullToEmptyString}}] [=extended attribute=] appears on the {{DOMString}} or {{USVString}} type,
-it creates a new IDL type such that that when a JavaScript <emu-val>null</emu-val> is converted to the IDL type,
+it creates a new IDL type such that when a JavaScript <emu-val>null</emu-val> is converted to the IDL type,
 it will be handled differently from its default handling. Instead of being stringified to
 "<code>null</code>", which is the default, it will be converted to the empty string.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->
This patch makes types such as `[Clamp] long?` legal, propagating the extended attribute to the inner type of the nullable type.

It relaxes the definitions of `[AllowResizable]`, `[AllowShared]`, `[Clamp]` and `[EnforceRange]` so that they can be used as such; while it leaves `[LegacyNullToEmptyString]` as is since it does not really make sense to apply it to a nullable string (since then the attribute would be a no-op, given that the null is already handled).

Closes #670.

---

My motivation for doing this is that I will need it in https://github.com/whatwg/webidl/pull/1568.

---

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1624.html" title="Last updated on Sep 14, 2026, 1:41 PM UTC (20cc820)">Preview</a> | <a href="https://whatpr.org/webidl/1624/fad9b4c...20cc820.html" title="Last updated on Sep 14, 2026, 1:41 PM UTC (20cc820)">Diff</a>