### PR TITLE
Editorial: use the exclusive range where the range can be empty

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3228,10 +3228,10 @@ the same operation or constructor.
                 and "required" otherwise.
         1.  [=set/Append=] the [=tuple=] (|X|, |types|, |optionalityValues|) to |S|.
         1.  If |X| is declared to be [=variadic=], then:
-            1.  [=list/For each=] |i| in [=the range=] |n| to |max| − 1, inclusive:
+            1.  [=list/For each=] |i| in [=the exclusive range|the range=] |n| to |max|, exclusive:
                 1.  Let |t| be a [=type list=].
                 1.  Let |o| be an [=optionality list=].
-                1.  [=list/For each=] |j| in [=the range=] 0 to |n| − 1, inclusive:
+                1.  [=list/For each=] |j| in [=the exclusive range|the range=] 0 to |n|, exclusive:
                     1.  [=list/Append=] |types|[|j|] to |t|.
                     1.  [=list/Append=] |optionalityValues|[|j|] to |o|.
                 1.  [=list/For each=] |j| in [=the range=] |n| to |i|, inclusive:
@@ -3245,7 +3245,7 @@ the same operation or constructor.
                 a final, variadic argument), then [=iteration/break=].
             1.  Let |t| be a [=type list=].
             1.  Let |o| be an [=optionality list=].
-            1.  [=list/For each=] |j| in [=the range=] 0 to |i| − 1, inclusive:
+            1.  [=list/For each=] |j| in [=the exclusive range|the range=] 0 to |i|, exclusive:
                 1.  [=list/Append=] |types|[|j|] to |t|.
                 1.  [=list/Append=] |optionalityValues|[|j|] to |o|.
             1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
@@ -9328,8 +9328,8 @@ a reference to the same object that the IDL value represents.
     1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then return the empty
         [=byte sequence=].
     1.  Let |bytes| be a new [=byte sequence=] of [=byte sequence/length=] equal to |length|.
-    1.  For |i| in [=the range=] |offset| to |offset| + |length| &minus; 1, inclusive, set
-        |bytes|[|i| &minus; |offset|] to [$GetValueFromBuffer$](|jsArrayBuffer|, |i|, Uint8,
+    1.  For |i| in [=the exclusive range|the range=] |offset| to |offset| + |length|, exclusive,
+        set |bytes|[|i| &minus; |offset|] to [$GetValueFromBuffer$](|jsArrayBuffer|, |i|, Uint8,
         true, Unordered).
     1.  Return |bytes|.
 </div>
@@ -9370,9 +9370,10 @@ a reference to the same object that the IDL value represents.
         |arrayBuffer| to a JavaScript value.
     1.  Assert: |bytes|'s [=byte sequence/length=] ≤ |jsArrayBuffer|.\[[ArrayBufferByteLength]]
         &minus; |startingOffset|.
-    1.  For |i| in [=the range=] |startingOffset| to |startingOffset| + |bytes|'s [=byte
-        sequence/length=] &minus; 1, inclusive, perform [$SetValueInBuffer$](|jsArrayBuffer|,
-        |i|, Uint8, |bytes|[|i| - |startingOffset|], true, Unordered).
+    1.  For |i| in [=the exclusive range|the range=] |startingOffset| to |startingOffset| +
+        |bytes|'s [=byte sequence/length=], exclusive, perform
+        [$SetValueInBuffer$](|jsArrayBuffer|, |i|, Uint8, |bytes|[|i| - |startingOffset|], true,
+        Unordered).
 </div>
 
 <div algorithm="ArrayBufferView/write">


### PR DESCRIPTION
Several algorithms iterated with "the range 0 to X − 1, inclusive", which is a decreasing range when X is 0. Infra only defines "the range n to m, inclusive" for m greater than or equal to n, so those cases were not well-defined, even though the empty ordered set was clearly what was intended — see for instance the note about *i* being 0 in the overload set construction.

Switch to "the range n to m, exclusive", which Infra already defines to create an empty ordered set when m equals n. This needs no Infra change.

Sites changed:

* "create an overload set": `|n|` to `|max|`, `0` to `|n|`, and `0` to `|i|`. The remaining `|n|` to `|i|`, inclusive is left alone, since `|i|` is always greater than or equal to `|n|` there.
* "get a copy of the bytes held by the buffer source", which was decreasing for a zero-length buffer source.
* "write into an `ArrayBuffer`", which was decreasing for an empty byte sequence.
